### PR TITLE
print valid names

### DIFF
--- a/src/rosdistro/__init__.py
+++ b/src/rosdistro/__init__.py
@@ -138,7 +138,7 @@ def get_release_file(index, dist_name):
 
 def get_release_cache(index, dist_name):
     if dist_name not in index.distributions.keys():
-        raise RuntimeError("Unknown release: '{0}'".format(dist_name))
+        raise RuntimeError("Unknown release: '{0}'. Valid release names are '{1}'".format(dist_name, index.distributions.keys()))
     dist = index.distributions[dist_name]
     if 'release_cache' not in dist.keys():
         raise RuntimeError("Release has no cache: '{0}'".format(dist_name))


### PR DESCRIPTION
As a help for users, so that they do not get 

```
Unknown release: 'fuerte'
```

and start trying numeric values, or something. 

I also though about changing the "Unknown release:" prefix for known but unsupported distros like fuerte, electric, diamondback, etc., but I am not passionate about this, and just changed roslocate to consider the prefix as it is. If that wrre to be improved, I'd vote for specific Error classes rather than RuntimeError.
