### PR TITLE
Fix Windows URL path for dist files.

### DIFF
--- a/src/rosdistro/__init__.py
+++ b/src/rosdistro/__init__.py
@@ -218,6 +218,9 @@ def _get_dist_file_data(index, dist_name, type_):
         raise RuntimeError('unknown release type "%s"' % type_)
     url = dist[type_]
 
+    #Fix Windows path
+    url = url.replace('\\', '/')
+
     def _load_yaml_data(url):
         logger.debug('Load file from "%s"' % url)
         yaml_str = load_url(url)


### PR DESCRIPTION
Hi,

I'm using ROS on Windows (7 x64) and I had some issues using 'rosdep update'.
One issue was due to some URL malformation, I found a fix by ensuring that the URL is using strict '/' instead of Windows '\'.
Please consider merging the fix into the master branch.

Regards,

PS : I'm using the pip version of rosdep.
