### PR TITLE
aptdistro.py: fix parsing bug on 'Pre-Depends: '

### DIFF
--- a/src/rosdistro/aptdistro.py
+++ b/src/rosdistro/aptdistro.py
@@ -15,9 +15,9 @@ class AptDistro:
         self.dep = {}
         package = None
         for l in url.read().split('\n'):
-            if 'Package: ' in l:
+            if l.find('Package: ') == 0:
                 package = l.split('Package: ')[1]
-            if 'Depends: ' in l:
+            if l.find('Depends: ') == 0:
                 if not package:
                     raise RuntimeError("Found 'depends' but not 'package' while parsing the apt repository index file")
                 self.dep[package] = [d.split(' ')[0] for d in (l.split('Depends: ')[1].split(', '))]


### PR DESCRIPTION
The old parser failed in the presence of 'Pre-Depends: ' lines, such as:

```
Package: libsdformat1
Source: sdformat
Version: 1.4.11-1~precise
Architecture: amd64
Maintainer: Jose Luis Rivero <jrivero@osrfoundation.org>
Installed-Size: 1153
Pre-Depends: multiarch-support
Depends: libboost-filesystem1.46.1 (>= 1.46.1-1), libboost-regex1.46.1 (>= 1.46.1-1), libboost-system1.46.1 (>= 1.46.1-1), libc6 (>= 2.14), libgcc1 (>= 1:4.1.1), libstdc++6 (>= 4.6), libtinyxml2.6.2
Conflicts: libsdformat1-nightly, libsdformat1-prerelease, sdformat, sdformat-nightly, sdformat-prerelease
Provides: libsdformat1-provider
Multi-Arch: same
Homepage: http://sdformat.org
Priority: extra
Section: libs
Filename: pool/main/s/sdformat/libsdformat1_1.4.11-1~precise_amd64.deb
Size: 357628
SHA256: ee95fb583dc3af8a41d3234a95a9e32a15e9fb116000c7444198c5eeef9ac835
SHA1: 56035b6660b30484f12d38a55d55995382704d29
MD5sum: bcff7e2c0a12e445fc4dae0f37ddb608
Description: Simulation Description Format (SDF) parser - Shared library
 SDF is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications. SDF is capable of representing
 and describing different physic engines, lighting properties, terrain, static
 or dynamic objects, and articulated robots with various sensors, and acutators.
 The format of SDF is also described by XML, which facilitates updates and
 allows conversion from previous versions. A parser is also contained within
 this package that reads SDF files and returns a C++ interface.
```

Entries such as this lead to the following error message:

```
"Found 'depends' but not 'package' while parsing the apt repository index file"
```

Enforcing that 'Depends: ' starts the line fixes that. This commit also 
enforces the same thing for 'Package: ' lines.
