### PR TITLE
Proper check of debian version according to Debian Versioning Policy

### DIFF
--- a/src/rosdistro/distribution_cache_generator.py
+++ b/src/rosdistro/distribution_cache_generator.py
@@ -95,7 +95,7 @@ def generate_distribution_cache(index, dist_name, preclean=False, ignore_local=F
             errors.append('%s: invalid package.xml file for package "%s": %s' % (dist_name, pkg_name, e))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s-\d+$' % re.escape(pkg.version), repo.version):
+        if not re.match('^%s-[\dA-z~\+\.]+$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
     if not debug:

--- a/src/rosdistro/release_cache_generator.py
+++ b/src/rosdistro/release_cache_generator.py
@@ -95,7 +95,7 @@ def generate_release_cache(index, dist_name, preclean=False, debug=False):
             errors.append('%s: invalid package.xml file for package "%s"' % (dist_name, pkg_name))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s-\d+$' % re.escape(pkg.version), repo.version):
+        if not re.match('^%s-[\dA-z~\+\.]+$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
     if not debug:


### PR DESCRIPTION
According to https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version : 
> debian_revision
>    This part of the version number specifies the version of the Debian package based on the upstream version. It may contain only alphanumerics and the characters + . ~ (plus, full stop, tilde) and is compared in the same way as the upstream_version is. 

This fix ensures that versions that are compliant with Debian standard are accepted by the cache generators.