### PR TITLE
Support url query parameters

### DIFF
--- a/src/rosdistro/__init__.py
+++ b/src/rosdistro/__init__.py
@@ -48,6 +48,10 @@ try:
 except ImportError:
     from io import BytesIO as StringIO
 import sys
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 import yaml
 
 logger = logging.getLogger('rosdistro')
@@ -113,7 +117,8 @@ def get_index(url):
     yaml_str = load_url(url)
     data = yaml.load(yaml_str)
     base_url = os.path.dirname(url)
-    return Index(data, base_url)
+    url_parts = urlparse(url)
+    return Index(data, base_url, url_query=url_parts.query)
 
 
 ### distribution information

--- a/src/rosdistro/index.py
+++ b/src/rosdistro/index.py
@@ -42,7 +42,7 @@ class Index(object):
 
     _type = 'index'
 
-    def __init__(self, data, base_url):
+    def __init__(self, data, base_url, url_query=''):
         assert 'type' in data, "Expected file type is '%s'" % Index._type
         assert data['type'] == Index._type, "Expected file type is '%s', not '%s'" % (Index._type, data['type'])
 
@@ -91,6 +91,8 @@ class Index(object):
                         parts = urlparse(v)
                         if not parts[0]:  # schema
                             v = base_url + '/' + v
+                            if url_query:
+                                v += '?' + url_query
                         self.distributions[distro_name][key].append(v)
                     if not list_value:
                         self.distributions[distro_name][key] = self.distributions[distro_name][key][0]

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -41,3 +41,34 @@ def test_get_index_v3_invalid():
         assert False
     except AssertionError:
         pass
+
+
+def test_get_index_from_http_with_query_parameters():
+    import subprocess
+    import sys
+    import time
+    url = 'http://localhost:9876/index_v3.yaml?raw&at=master'
+    # start a http server and wait
+    if sys.version_info < (3, 0, 0):
+        proc = subprocess.Popen([sys.executable, '-m', 'SimpleHTTPServer', '9876'],
+                                cwd=FILES_DIR)
+    else:
+        proc = subprocess.Popen([sys.executable, '-m', 'http.server', '9876'],
+                                cwd=FILES_DIR)
+    time.sleep(0.1)
+    try:
+        i = get_index(url)
+        assert len(i.distributions.keys()) == 1
+        assert 'foo' in i.distributions.keys()
+
+        # test if every url has the same queries
+        for dist_urls in i.distributions['foo'].values():
+            if not isinstance(dist_urls, list):
+                dist_urls = [dist_urls]
+            for dist_url in dist_urls:
+                assert dist_url.endswith('?raw&at=master')
+        dist_files = get_distribution_files(i, 'foo')
+        assert len(dist_files) == 2
+        get_distribution_file(i, 'foo')
+    finally:
+        proc.terminate()


### PR DESCRIPTION
Hi,

I'm using Atlassian Stash to manage my own ``rosdsitro``.
Unfortunately, in order to get a raw content of a file from Stash, I need to add query parameters like ``raw`` and ``at=``.
(http://stackoverflow.com/questions/14063008/get-raw-file-content-using-stash-rest-api)
Although there is already an issue, nothing has seemed to progress so far(https://jira.atlassian.com/browse/BSERV-4036) .

I would appreciate if url query parameters are supported, that is if ``index_url`` has query parameters then all the relative urls have the same queries.

Thanks.