### PR TITLE
fix retry on socket timeout with Python 3

### DIFF
--- a/src/rosdistro/loader.py
+++ b/src/rosdistro/loader.py
@@ -57,6 +57,8 @@ def load_url(url, retry=2, retry_period=1, timeout=10, skip_decode=False):
             time.sleep(retry_period)
             return load_url(url, retry=retry - 1, retry_period=retry_period, timeout=timeout)
         raise URLError(str(e) + ' (%s)' % url)
+    except socket.timeout as e:
+        raise socket.timeout(str(e) + ' (%s)' % url)
     # Python 2/3 Compatibility
     contents = fh.read()
     if isinstance(contents, str) or skip_decode:


### PR DESCRIPTION
Same patch as in ros-infrastructure/ros_buildfarm#168

This fix should be released asap since jobs are failing due to this: e.g. http://build.ros.org/job/Jbin_arm_uThf__rviz_python_tutorial__ubuntu_trusty_armhf__binary/3/console