### PR TITLE
add catch of 500 error codes as well

### DIFF
--- a/src/rosdistro/loader.py
+++ b/src/rosdistro/loader.py
@@ -47,7 +47,7 @@ def load_url(url, retry=2, retry_period=1, timeout=10, skip_decode=False):
     try:
         fh = urlopen(url, timeout=timeout)
     except HTTPError as e:
-        if e.code in [502, 503] and retry:
+        if e.code in [500, 502, 503] and retry:
             time.sleep(retry_period)
             return load_url(url, retry=retry - 1, retry_period=retry_period, timeout=timeout)
         e.msg += ' (%s)' % url


### PR DESCRIPTION
This is a follow on to #59 to add 500 as an error code to catch. 

I've seen several failures recently like this: 

```
Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py", line 148, in <module>
    main()
  File "/tmp/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py", line 51, in main
    dist_file = get_distribution_file(index, args.rosdistro_name)
  File "/usr/lib/python3/dist-packages/rosdistro/__init__.py", line 128, in get_distribution_file
    data = _get_dist_file_data(index, dist_name, 'distribution')
  File "/usr/lib/python3/dist-packages/rosdistro/__init__.py", line 319, in _get_dist_file_data
    data.append(_load_yaml_data(u))
  File "/usr/lib/python3/dist-packages/rosdistro/__init__.py", line 311, in _load_yaml_data
    yaml_str = load_url(url)
  File "/usr/lib/python3/dist-packages/rosdistro/loader.py", line 48, in load_url
    fh = urlopen(url, timeout=timeout)
  File "/usr/lib/python3.3/urllib/request.py", line 156, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.3/urllib/request.py", line 475, in open
    response = meth(req, response)
  File "/usr/lib/python3.3/urllib/request.py", line 587, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.3/urllib/request.py", line 513, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.3/urllib/request.py", line 447, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.3/urllib/request.py", line 595, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 500: Internal Server Error (https://raw.githubusercontent.com/ros/rosdistro/master/indigo/distribution.yaml)
```