### PR TITLE
Added Ubuntu Wily (15.10) and Xenial (16.04)

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-catkin-pkg, python-rospkg, python-setuptools, p
 Depends3: python3-catkin-pkg, python3-rospkg, python3-setuptools, python3-yaml
 Conflicts: python3-rosdistro
 Conflicts3: python-rosdistro
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wheezy jessie
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial wheezy jessie
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Added Ubuntu Wily (15.10) and Xenial (16.04) to the list of supported platforms.