### PR TITLE
Make debian increment optional when comparing versions.

### DIFF
--- a/src/rosdistro/distribution_cache_generator.py
+++ b/src/rosdistro/distribution_cache_generator.py
@@ -95,7 +95,7 @@ def generate_distribution_cache(index, dist_name, preclean=False, ignore_local=F
             errors.append('%s: invalid package.xml file for package "%s": %s' % (dist_name, pkg_name, e))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s-[\dA-z~\+\.]+$' % re.escape(pkg.version), repo.version):
+        if not re.match('^%s(-[\dA-z~\+\.]+)?$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
     if not debug:

--- a/src/rosdistro/release_cache_generator.py
+++ b/src/rosdistro/release_cache_generator.py
@@ -95,7 +95,7 @@ def generate_release_cache(index, dist_name, preclean=False, debug=False):
             errors.append('%s: invalid package.xml file for package "%s"' % (dist_name, pkg_name))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s-[\dA-z~\+\.]+$' % re.escape(pkg.version), repo.version):
+        if not re.match('^%s(-[\dA-z~\+\.]+)?$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
     if not debug:


### PR DESCRIPTION
This is for cases when you want to include packages in a cache (and thus available to rosinstall_generator) without making a bloomed release of them, for example by referencing the upstream directly in the `release` stanza, eg:

```
  libg2o:
    release:
      tags:
        release: "{version}"
      url: https://github.com/mikepurvis/libg2o.git
      version: 2016.2.23
    source:
      type: git
      url: https://github.com/mikepurvis/libg2o.git
      version: indigo-devel
```

Without the proposed change, the above results in a ridiculous error message like this:

```
$ rosdistro_build_cache index.yaml                                                                                                         
Build cache for "clearpath"
- trying to use local cache
- use local file "clearpath-cache.yaml.gz"
- update cache
- fetch missing manifests
.........................................................................................................................................................................................................
.........................................................................................................................................................................................................
.........................................................................
clearpath: different version in package.xml (2016.2.23) for package "libg2o" than for the repository (2016.2.23) (after removing the debian increment)
```