### PR TITLE
New script: rosdistro_freeze_source

### DIFF
--- a/scripts/rosdistro_freeze_source
+++ b/scripts/rosdistro_freeze_source
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Clearpath Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os.path
+import sys
+import yaml
+
+from rosdistro import get_distribution
+from rosdistro.index import Index
+from rosdistro.freeze_source import freeze_distribution_sources, CONCURRENT_DEFAULT
+from rosdistro.writer import yaml_from_distribution_file
+
+
+def parse_args(args=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='''
+        Freeze a rosdistro\'s source branch versions to hashes or tags. If neither --release-version
+        nor --release-tag are specified, the hashes of the current devel branches are used.
+        ''')
+    parser.add_argument('index', type=argparse.FileType(),
+                        help='Path to a local index.yaml file.')
+    parser.add_argument('dist_names', nargs='*', help='The names of the distributions (default: all)')
+    parser.add_argument('-j', '--jobs', type=int, default=CONCURRENT_DEFAULT,
+                        help='How many worker threads to use.')
+    parser.add_argument('-q', '--quiet', action="store_true",
+                        help='Suppress updating status bar (for script/CI usage).')
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument('--release-version', action="store_true",
+                      help='Freeze to the hash of current release tag.')
+    mode.add_argument('--release-tag', action="store_true",
+                      help='Freeze to name of current release tag.')
+    return parser.parse_args(args)
+
+
+def main():
+    args = parse_args()
+    index = Index(yaml.safe_load(args.index),
+            'file://%s' % os.path.dirname(os.path.abspath(args.index.name)))
+
+    if not args.dist_names:
+        args.dist_names = sorted(index.distributions.keys())
+
+    for dist_name in args.dist_names:
+        dist = get_distribution(index, dist_name)
+        freeze_distribution_sources(dist, release_version=args.release_version, release_tag=args.release_tag,
+                                    concurrent_ops=args.jobs, quiet=args.quiet)
+        dist_file_local = index.distributions[dist_name]['distribution'].split('://')[1]
+        with open(dist_file_local, 'w') as f:
+            f.write(yaml_from_distribution_file(dist))
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     scripts=[
 #        'scripts/rosdistro',
         'scripts/rosdistro_build_cache',
+        'scripts/rosdistro_freeze_source',
 #        'scripts/rosdistro_convert',
 #        'scripts/rosdistro_generate_cache',
         'scripts/rosdistro_migrate_to_rep_141',

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Clearpath Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import sys
+import subprocess
+import threading
+import time
+import yaml
+
+try:
+    import queue
+except ImportError:
+    import Queue as queue
+
+CONCURRENT_DEFAULT = 16
+
+
+def freeze_distribution_sources(dist, release_version=False, release_tag=False,
+                                concurrent_ops=CONCURRENT_DEFAULT, quiet=False):
+    # Populate this queue with tuples of repositories instances to be updated,
+    # so that this work can be spread across multiple threads.
+    work_queue = queue.Queue()
+    for repo_name, repo in dist.repositories.iteritems():
+        # Only manipulate distribution entries with a source repo listed.
+        if repo.source_repository:
+            # Decide which git ref string we'll be using as the replacement match.
+            if repo.release_repository and (release_version or release_tag):
+                version = repo.release_repository.version.split('-')[0]
+            else:
+                version = repo.source_repository.version
+            work_queue.put((repo.source_repository, version, release_tag))
+
+    total_items = work_queue.qsize()
+
+    for i in range(concurrent_ops):
+        threading.Thread(target=_worker, args=[work_queue]).start()
+
+    # Wait until the threads have done all the work and exited.
+    while not work_queue.empty():
+        time.sleep(0.1)
+        if not quiet:
+            sys.stdout.write("Updating source repo versions (%d/%d)   \r" %
+                             (total_items - work_queue.qsize(), total_items))
+            sys.stdout.flush()
+    work_queue.join()
+
+    # Clear past the updating line.
+    if not quiet:
+        print("")
+
+
+def _worker(work_queue):
+    while True:
+        try:
+            source_repo, freeze_version, freeze_to_tag = work_queue.get(block=False)
+            cmd = ['git', 'ls-remote', source_repo.url]
+            ls_remote_lines = subprocess.check_output(cmd).splitlines()
+            for line in ls_remote_lines:
+                hash, ref = line.split('\t', 1)
+                if ref.endswith(freeze_version):
+                    if freeze_to_tag and ref.startswith('refs/tags/'):
+                        source_repo.version = ref.split('refs/tags/')[1]
+                    else:
+                        source_repo.version = hash
+                    break
+
+            work_queue.task_done()
+
+        except subprocess.CalledProcessError:
+            print("Non-zero return code for: %s" % ' '.join(cmd), file=sys.stderr)
+            work_queue.task_done()
+
+        except queue.Empty:
+            break


### PR DESCRIPTION
This script offers new functionality for users looking to create reproducible snapshots of _upstream source_, across an entire distro. This tool is a building block in a larger intended workflow, which is:

- freeze the distro.
- generate a cache specific to the frozen state, update index.yaml to point to it.
- tag the distro.
- use rosinstall_generator, ros_buildfarm, etc against the tagged index.yaml
- the frozen state may be "awakened" by committing the tag as a branch, and transforming select source versions _back_ to development branches, allowing development and source-based testing to resume from the point in the past.

Example uses:

```
$ git clone https://github.com/clearpathrobotics/public-rosdistro.git
$ cd public-rosdistro

# Change version pointers to hash from devel branches
$ rosdistro_freeze_source index.yaml indigo  # Implies --source-version
$ git diff
$ git checkout .

# Change version pointers to hash from latest release
$ rosdistro_freeze_source index.yaml indigo --release-version
$ git diff
$ git checkout .

# Change version pointers to tag name from latest release
rosdistro_freeze_source index.yaml indigo --release-tag
git diff

# Options
$ rosdistro_freeze_source -h
usage: rosdistro_freeze_source [-h]
                               [--source-version | --release-version | --release-tag]
                               index [dist_names [dist_names ...]]

Freeze a rosdistro's source branch versions to hashes or tags.

positional arguments:
  index              Path to a local index.yaml file.
  dist_names         The names of the distributions (default: all)

optional arguments:
  -h, --help         show this help message and exit
  --source-version   Freeze to the hash of current source branch (default).
  --release-version  Freeze to the hash of current release tag.
  --release-tag      Freeze to name of current release tag.
```

@dirk-thomas 