### PR TITLE
print package name if manifest was updated

### DIFF
--- a/src/rosdistro/distribution_cache_generator.py
+++ b/src/rosdistro/distribution_cache_generator.py
@@ -84,6 +84,9 @@ def generate_distribution_cache(index, dist_name, preclean=False, ignore_local=F
             sys.stdout.write('.')
             sys.stdout.flush()
         # check that package.xml is fetchable
+        old_package_xml = None
+        if cache and pkg_name in cache.release_package_xmls:
+            old_package_xml = cache.release_package_xmls[pkg_name]
         package_xml = dist.get_release_package_xml(pkg_name)
         if not package_xml:
             errors.append('%s: missing package.xml file for package "%s"' % (dist_name, pkg_name))
@@ -97,6 +100,9 @@ def generate_distribution_cache(index, dist_name, preclean=False, ignore_local=F
         # check that version numbers match (at least without deb inc)
         if not re.match('^%s-[\dA-z~\+\.]+$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
+
+        if package_xml != old_package_xml:
+            print("  - updated manifest of package '%s' to version '%s'" % (pkg_name, pkg.version))
 
     if not debug:
         print('')


### PR DESCRIPTION
This is necessary for ros-infrastructure/ros_buildfarm#235.

Once this is merged I will do a new patch release.