### PR TITLE
Fix for cache updating.

### DIFF
--- a/src/rosdistro/distribution_cache_generator.py
+++ b/src/rosdistro/distribution_cache_generator.py
@@ -130,14 +130,15 @@ def _get_cached_distribution(index, dist_name, preclean=False, ignore_local=Fals
                 print('- trying to fetch cache')
                 # get distribution cache
                 cache = get_distribution_cache(index, dist_name)
-            # get current distribution file
-            rel_file_data = _get_dist_file_data(index, dist_name, 'distribution')
-            # update cache with current distribution file
-            cache.update_distribution(rel_file_data)
     except Exception as e:
         print('- failed to fetch old cache: %s' % e)
+
     if cache:
         print('- update cache')
+        # get current distribution file
+        rel_file_data = _get_dist_file_data(index, dist_name, 'distribution')
+        # update cache with current distribution file
+        cache.update_distribution(rel_file_data)
     else:
         print('- build cache from scratch')
         # get empty cache with distribution file

--- a/src/rosdistro/release_cache_generator.py
+++ b/src/rosdistro/release_cache_generator.py
@@ -129,14 +129,15 @@ def _get_cached_release(index, dist_name, preclean=False):
                 print('- trying to fetch cache')
                 # get release cache
                 cache = get_release_cache(index, dist_name)
-            # get current release file
-            rel_file_data = _get_dist_file_data(index, dist_name, 'release')
-            # update cache with current release file
-            cache.update_distribution(rel_file_data)
     except:
         print('- failed to fetch old cache')
+
     if cache:
         print('- update cache')
+        # get current release file
+        rel_file_data = _get_dist_file_data(index, dist_name, 'release')
+        # update cache with current release file
+        cache.update_distribution(rel_file_data)
     else:
         print('- build cache from scratch')
         # get empty cache with distribution file


### PR DESCRIPTION
This fixes a nasty little bug I ran into where my cache got corrupted and then wasn't getting the distribution portion updated any longer:

```
$ rosdistro_build_cache index.yaml indigo
Build cache for "indigo"
- trying to use local cache
- use local file "indigo-cache.yaml.gz"
- failed to fetch old cache: string indices must be integers, not str
- update cache
- fetch missing manifests
............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
- write cache file "indigo-cache.yaml"
```