### PR TITLE
Refactor manifest provider utility functions

### DIFF
--- a/src/rosdistro/manifest_provider/__init__.py
+++ b/src/rosdistro/manifest_provider/__init__.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+# This function remains here as a compatibility shim because there
+# is code in rosinstall_generator which uses it in this location.
 def get_release_tag(repo, pkg_name):
-    """ Compatibility shim. """
     return repo.get_release_tag(pkg_name)

--- a/src/rosdistro/manifest_provider/__init__.py
+++ b/src/rosdistro/manifest_provider/__init__.py
@@ -33,13 +33,5 @@
 
 
 def get_release_tag(repo, pkg_name):
-    data = {
-        'package': pkg_name
-    }
-    if repo.version is not None:
-        data['version'] = repo.version
-        data['upstream_version'] = repo.version.split('-')[0]
-    release_tag = repo.tags['release']
-    for k, v in data.items():
-        release_tag = release_tag.replace('{%s}' % k, v)
-    return release_tag
+    """ Compatibility shim. """
+    return repo.get_release_tag(pkg_name)

--- a/src/rosdistro/manifest_provider/bitbucket.py
+++ b/src/rosdistro/manifest_provider/bitbucket.py
@@ -65,7 +65,7 @@ def bitbucket_manifest_provider(_dist_name, repo, pkg_name):
 
     release_tag = repo.get_release_tag(pkg_name)
 
-    if release_tag not in repo.remote_tags:
+    if not repo.has_remote_tag(release_tag):
         raise RuntimeError('specified tag "%s" is not a git tag' % release_tag)
 
     url = 'https://bitbucket.org/%s/raw/%s/package.xml' % (path, release_tag)

--- a/src/rosdistro/manifest_provider/git.py
+++ b/src/rosdistro/manifest_provider/git.py
@@ -31,14 +31,12 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from distutils.version import LooseVersion
 import os
 import shutil
-import subprocess
 import tempfile
 
 from rosdistro import logger
-from rosdistro.manifest_provider import get_release_tag
+from rosdistro.vcs import Git
 
 
 workspace_base = '/tmp/rosdistro-workspace'
@@ -47,51 +45,39 @@ workspace_base = '/tmp/rosdistro-workspace'
 def git_manifest_provider(_dist_name, repo, pkg_name):
     assert repo.version
     try:
-        release_tag = get_release_tag(repo, pkg_name)
+        release_tag = repo.get_release_tag(pkg_name)
         package_xml = _get_package_xml(repo.url, release_tag)
         return package_xml
     except Exception as e:
         raise RuntimeError('Unable to fetch package.xml: %s' % e)
 
 
-def _git_version_gte(version):
-    global _git_client_version
-    if not _git_client_version:
-        cmd = [_git_client_executable, '--version']
-        result = _run_command(cmd)
-        _git_client_version = result['output'].split()[-1]
-    return LooseVersion(_git_client_version) >= LooseVersion(version)
-
-
 def _get_package_xml(url, tag):
     base = tempfile.mkdtemp('rosdistro')
     try:
-        assert _git_client_executable is not None, "'git' not found"
-        if _git_version_gte('1.8.0'):
+        git = Git(base)
+        if git.version_gte('1.8.0'):
             # Directly clone the required tag with least amount of additional history. This behaviour
             # has been available since git 1.8.0:
             # https://git.kernel.org/cgit/git/git.git/tree/Documentation/git-clone.txt?h=v1.8.0#n158
-            cmd = [_git_client_executable, 'clone', url, base, '--depth', '1', '--branch', tag]
-            result = _run_command(cmd, base)
+            result = git.command('clone', url, base, '--depth', '1', '--branch', tag)
             if result['returncode'] != 0:
                 raise RuntimeError('Could not clone repository "%s" at tag "%s"' % (url, tag))
         else:
             # Old git doesn't support cloning a tag directly, so check it out after a full clone.
-            cmd = [_git_client_executable, 'clone', url, base]
-            result = _run_command(cmd, base)
+            git = Git(base)
+            result = git.command('clone', url, base)
             if result['returncode'] != 0:
                 raise RuntimeError('Could not clone repository "%s"' % url)
 
-            cmd = [_git_client_executable, 'tag', '-l']
-            result = _run_command(cmd, base)
+            result = git.command('tag', '-l')
             if result['returncode'] != 0:
                 raise RuntimeError('Could not get tags of repository "%s"' % url)
 
             if tag not in result['output'].splitlines():
                 raise RuntimeError('Specified tag "%s" is not a git tag of repository "%s"' % (tag, url))
 
-            cmd = [_git_client_executable, 'checkout', tag]
-            result = _run_command(cmd, base)
+            result = git.command('checkout', tag)
             if result['returncode'] != 0:
                 raise RuntimeError('Could not checkout tag "%s" of repository "%s"' % (tag, url))
 
@@ -102,47 +88,3 @@ def _get_package_xml(url, tag):
             return f.read()
     finally:
         shutil.rmtree(base)
-
-
-def check_remote_tag_exists(url, tag):
-    base = tempfile.mkdtemp('rosdistro')
-    try:
-        assert _git_client_executable is not None, "'git' not found"
-        cmd = [_git_client_executable, 'ls-remote', '--tags', url]
-        result = _run_command(cmd, base)
-        if result['returncode'] != 0:
-            logger.debug('Could not list remote tags of repository "%s": %s' % (url, result['output']))
-        else:
-            suffix = '\trefs/tags/%s' % tag
-            for line in result['output'].splitlines():
-                if line.endswith(suffix):
-                    return True
-    finally:
-        shutil.rmtree(base)
-    return False
-
-
-def _run_command(cmd, cwd=None, env=None):
-    result = {'cmd': ' '.join(cmd), 'cwd': cwd}
-    try:
-        proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
-        output, _ = proc.communicate()
-        result['output'] = output.rstrip()
-        result['returncode'] = proc.returncode
-    except subprocess.CalledProcessError as e:
-        result['output'] = e.output
-        result['returncode'] = e.returncode
-    if not isinstance(result['output'], str):
-        result['output'] = result['output'].decode('utf-8')
-    return result
-
-
-def _find_executable(file_name):
-    for path in os.getenv('PATH').split(os.path.pathsep):
-        file_path = os.path.join(path, file_name)
-        if os.path.isfile(file_path) and os.access(file_path, os.X_OK):
-            return file_path
-    return None
-
-_git_client_executable = _find_executable('git')
-_git_client_version = None

--- a/src/rosdistro/manifest_provider/git.py
+++ b/src/rosdistro/manifest_provider/git.py
@@ -63,9 +63,8 @@ def git_manifest_provider(_dist_name, repo, pkg_name):
 @contextmanager
 def _temp_git_clone(url, ref):
     base = tempfile.mkdtemp('rosdistro')
-    git = Git(base)
+    git = Git(cwd=base)
     try:
-        git = Git(cwd=base)
         if git.version_gte('1.8.0') and not _ref_is_hash(ref):
             # Directly clone the required ref with least amount of additional history. This behaviour
             # has been available since git 1.8.0, but only works for tags and branches, not hashes:

--- a/src/rosdistro/manifest_provider/git.py
+++ b/src/rosdistro/manifest_provider/git.py
@@ -55,7 +55,7 @@ def git_manifest_provider(_dist_name, repo, pkg_name):
 def _get_package_xml(url, tag):
     base = tempfile.mkdtemp('rosdistro')
     try:
-        git = Git(base)
+        git = Git(cwd=base)
         if git.version_gte('1.8.0'):
             # Directly clone the required tag with least amount of additional history. This behaviour
             # has been available since git 1.8.0:

--- a/src/rosdistro/manifest_provider/git.py
+++ b/src/rosdistro/manifest_provider/git.py
@@ -65,7 +65,6 @@ def _get_package_xml(url, tag):
                 raise RuntimeError('Could not clone repository "%s" at tag "%s"' % (url, tag))
         else:
             # Old git doesn't support cloning a tag directly, so check it out after a full clone.
-            git = Git(base)
             result = git.command('clone', url, base)
             if result['returncode'] != 0:
                 raise RuntimeError('Could not clone repository "%s"' % url)

--- a/src/rosdistro/manifest_provider/github.py
+++ b/src/rosdistro/manifest_provider/github.py
@@ -39,32 +39,24 @@ except ImportError:
     from urllib2 import URLError
 
 from rosdistro import logger
-from rosdistro.manifest_provider import get_release_tag
-from rosdistro.manifest_provider.git import check_remote_tag_exists
 
 
 def github_manifest_provider(_dist_name, repo, pkg_name):
     assert repo.version
-    if 'github.com' not in repo.url:
+    server, path = repo.get_url_parts()
+    if server != 'github.com':
         logger.debug('Skip non-github url "%s"' % repo.url)
         raise RuntimeError('can not handle non github urls')
 
-    release_tag = get_release_tag(repo, pkg_name)
+    release_tag = repo.get_release_tag(pkg_name)
 
-    if not check_remote_tag_exists(repo.url, release_tag):
+    if release_tag not in repo.remote_tags:
         raise RuntimeError('specified tag "%s" is not a git tag' % release_tag)
 
-    url = repo.url
-    if url.endswith('.git'):
-        url = url[:-4]
-    url += '/%s/package.xml' % release_tag
-    if url.startswith('git://'):
-        url = 'https://' + url[6:]
-    if url.startswith('https://'):
-        url = 'https://raw.' + url[8:]
+    url = 'https://raw.githubusercontent.com/%s/%s/package.xml' % (path, release_tag)
     try:
         logger.debug('Load package.xml file from url "%s"' % url)
-        package_xml = urlopen(url).read()
+        package_xml = urlopen(url).read().decode('utf-8')
         return package_xml
     except URLError as e:
         logger.debug('- failed (%s), trying "%s"' % (e, url))

--- a/src/rosdistro/manifest_provider/github.py
+++ b/src/rosdistro/manifest_provider/github.py
@@ -50,7 +50,7 @@ def github_manifest_provider(_dist_name, repo, pkg_name):
 
     release_tag = repo.get_release_tag(pkg_name)
 
-    if release_tag not in repo.remote_tags:
+    if not repo.has_remote_tag(release_tag):
         raise RuntimeError('specified tag "%s" is not a git tag' % release_tag)
 
     url = 'https://raw.githubusercontent.com/%s/%s/package.xml' % (path, release_tag)

--- a/src/rosdistro/release_repository_specification.py
+++ b/src/rosdistro/release_repository_specification.py
@@ -59,6 +59,18 @@ class ReleaseRepositorySpecification(RepositorySpecification):
         # for backward compatibility only
         self.release_repository = self
 
+    def get_release_tag(self, pkg_name):
+        data = {
+            'package': pkg_name
+        }
+        if self.version:
+            data['version'] = self.version
+            data['upstream_version'] = self.version.split('-')[0]
+        release_tag = self.tags['release']
+        for k, v in data.items():
+            release_tag = release_tag.replace('{%s}' % k, v)
+        return release_tag
+
     def get_data(self):
         data = self._get_data(skip_git_type=True)
         if self.tags:

--- a/src/rosdistro/repository_specification.py
+++ b/src/rosdistro/repository_specification.py
@@ -55,12 +55,14 @@ class RepositorySpecification(object):
         return self._get_data()
 
     def get_url_parts(self):
-        """ Returns a tuple for the server and path.
-            Example ('github.com', 'ros/catkin') """
+        """ Returns a tuple for the server and path, eg ('github.com', 'ros/catkin') """
         match = self.VCS_REGEX.match(self.url)
         if not match:
             raise RuntimeError('VCS url "%s" does not match expected format.' % self.url)
         return match.groups()
+
+    def has_remote_tag(self, tag):
+        return tag in self.remote_tags
 
     @property
     def remote_refs(self):

--- a/src/rosdistro/vcs.py
+++ b/src/rosdistro/vcs.py
@@ -1,0 +1,80 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Clearpath Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from distutils.version import LooseVersion
+import os
+import subprocess
+
+
+class Git(object):
+    _client_executable = None
+    _client_version = None
+
+    def __init__(self, cwd=None):
+        self.cwd = cwd
+        if not self._client_executable:
+            self.__class__._client_executable = _find_executable('git')
+
+    def command(self, *args):
+        assert self._client_executable is not None, "'git' not found"
+        return _run_command((self._client_executable,) + args, self.cwd)
+
+    @classmethod
+    def version_gte(cls, version):
+        if not cls._client_version:
+            result = cls().command('--version')
+            cls._client_version = result['output'].split()[-1]
+        return LooseVersion(cls._client_version) >= LooseVersion(version)
+
+
+def _run_command(cmd, cwd=None, env=None):
+    result = {'cmd': ' '.join(cmd), 'cwd': cwd}
+    try:
+        proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+        output, _ = proc.communicate()
+        result['output'] = output.rstrip()
+        result['returncode'] = proc.returncode
+    except subprocess.CalledProcessError as e:
+        result['output'] = e.output
+        result['returncode'] = e.returncode
+    if not isinstance(result['output'], str):
+        result['output'] = result['output'].decode('utf-8')
+    return result
+
+
+def _find_executable(file_name):
+    for path in os.getenv('PATH').split(os.path.pathsep):
+        file_path = os.path.join(path, file_name)
+        if os.path.isfile(file_path) and os.access(file_path, os.X_OK):
+            return file_path
+    return None

--- a/src/rosdistro/vcs.py
+++ b/src/rosdistro/vcs.py
@@ -1,5 +1,6 @@
 # Software License Agreement (BSD License)
 #
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
 # Copyright (c) 2016, Clearpath Robotics
 # All rights reserved.
 #

--- a/test/test_manifest_providers.py
+++ b/test/test_manifest_providers.py
@@ -1,0 +1,55 @@
+import os
+
+from rosdistro.manifest_provider.bitbucket import bitbucket_manifest_provider
+from rosdistro.manifest_provider.cache import CachedManifestProvider
+from rosdistro.manifest_provider.git import git_manifest_provider
+from rosdistro.manifest_provider.github import github_manifest_provider
+from rosdistro.release_repository_specification import ReleaseRepositorySpecification
+
+import rosdistro.vcs
+
+
+def test_bitbucket():
+    assert '</package>' in bitbucket_manifest_provider('indigo', _rospeex_repo(), 'rospeex_msgs')
+
+
+def test_cached():
+    class FakeDistributionCache(object):
+        def __init__(self):
+            self.release_package_xmls = {}
+    dc = FakeDistributionCache()
+    cache = CachedManifestProvider(dc, [ github_manifest_provider ])
+    assert '</package>' in cache('kinetic', _genmsg_repo(), 'genmsg')
+
+
+def test_git():
+    assert '</package>' in git_manifest_provider('kinetic', _genmsg_repo(), 'genmsg')
+
+
+def test_git_legacy():
+    rosdistro.vcs._git_client_version = '1.7.0'
+    assert '</package>' in git_manifest_provider('kinetic', _genmsg_repo(), 'genmsg')
+    rosdistro.vcs._git_client_version = None
+
+
+def test_github():
+    assert '</package>' in github_manifest_provider('kinetic', _genmsg_repo(), 'genmsg')
+
+
+def _genmsg_repo():
+    return ReleaseRepositorySpecification('genmsg', {
+        'url': 'https://github.com/ros-gbp/genmsg-release.git',
+        'tags': { 'release': 'release/kinetic/{package}/{version}' },
+        'version': '0.5.7-1'
+    })
+
+
+def _rospeex_repo():
+    return ReleaseRepositorySpecification('rospeex', {
+        'packages': [ 'rospeex', 'rospeex_msgs' ],
+        'tags': { 'release': 'release/indigo/{package}/{version}' },
+        'url': 'https://bitbucket.org/rospeex/rospeex-release.git',
+        'version': '2.14.7-0'
+    })
+
+

--- a/test/test_repository_specification.py
+++ b/test/test_repository_specification.py
@@ -1,0 +1,22 @@
+import os
+
+from rosdistro.repository_specification import RepositorySpecification
+
+def test_repository_specification():
+    data = { 'type': 'git', 'url': 'https://github.com/ros/catkin.git' }
+    r = RepositorySpecification("test", data)
+    assert r.get_data() == data
+    assert r.version == None
+    assert r.get_url_parts() == ('github.com', 'ros/catkin')
+
+    r.url = 'http://github.com/ros/catkin'
+    assert r.get_url_parts() == ('github.com', 'ros/catkin')
+
+    r.url = 'ssh://example.com/a/b/c.git'
+    assert r.get_url_parts() == ('example.com', 'a/b/c')
+
+    r.url = 'git://example.com/a/b/c/d.git'
+    assert r.get_url_parts() == ('example.com', 'a/b/c/d')
+
+    r.url = 'git@example.com:a/b/c/d/e.git'
+    assert r.get_url_parts() == ('example.com', 'a/b/c/d/e')


### PR DESCRIPTION
Some more stuff I need for #78 that will be helpful to merge in advance:

- Created new `rosdistro.vcs` module with `Git` class having `command` and `version_gte` methods, to take the place of the loose stuff that used to be in `rosdistro.manifest_providers.git`.
- Moved `get_release_tag` from `rosdistro.manifest_providers` to a member function of `ReleaseRepositorySpecification`.
- Dropped `check_remote_tag_exists` from `rosdistro.manifest_providers.git`, in favour of a property on `RepositorySpecification` that returns (with caching) remote references and remote tags.
- Added some tests to cover the basic functionality of the manifest providers.

@dirk-thomas 