### PR TITLE
add ca-certificates dependency to access https urls

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-argparse, python-catkin-pkg, python-rospkg, python-setuptools, python-yaml
-Depends3: python3-catkin-pkg, python3-rospkg, python3-setuptools, python3-yaml
+Depends: ca-certificates, python-argparse, python-catkin-pkg, python-rospkg, python-setuptools, python-yaml
+Depends3: ca-certificates, python3-catkin-pkg, python3-rospkg, python3-setuptools, python3-yaml
 Conflicts: python3-rosdistro
 Conflicts3: python-rosdistro
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial wheezy jessie


### PR DESCRIPTION
Otherwise it will fail to pull our default on python systems > 2.7.9

Example failure: 

```
root@838546e227ad:/# rosdistro_build_cache https://github.com/ros/rosdistro/raw/master/index.yaml
Traceback (most recent call last):
  File "/usr/bin/rosdistro_build_cache", line 99, in <module>
    main()
  File "/usr/bin/rosdistro_build_cache", line 80, in main
    caches = generate_distribution_caches(args.index, dist_names=args.dist_names, preclean=args.preclean, ignore_local=args.ignore_local, debug=args.debug)
  File "/usr/lib/python2.7/dist-packages/rosdistro/distribution_cache_generator.py", line 51, in generate_distribution_caches
    index = get_index(index)
  File "/usr/lib/python2.7/dist-packages/rosdistro/__init__.py", line 117, in get_index
    yaml_str = load_url(url)
  File "/usr/lib/python2.7/dist-packages/rosdistro/loader.py", line 59, in load_url
    raise URLError(str(e) + ' (%s)' % url)
urllib2.URLError: <urlopen error <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)> (https://github.com/ros/rosdistro/raw/master/index.yaml)>
```

Similar to https://github.com/ros-infrastructure/rosdep/pull/454