### PR TITLE
Better matching for tag/branch freezing.

### DIFF
--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -91,10 +91,10 @@ def _worker(work_queue):
             ls_remote_lines = subprocess.check_output(cmd).splitlines()
             for line in ls_remote_lines:
                 hash, ref = line.split('\t', 1)
-                if ref == 'refs/tags/%s' % freeze_version and freeze_to_tag:
+                if freeze_to_tag and ref == 'refs/tags/%s' % freeze_version:
                     source_repo.version = ref.split('refs/tags/')[1]
                     break
-                elif ref == 'refs/heads/%s' % freeze_version or ref == 'refs/tags/%s' % freeze_version:
+                elif ref in ('refs/heads/%s' % freeze_version, 'refs/tags/%s' % freeze_version):
                     source_repo.version = hash
                     break
 

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -91,11 +91,11 @@ def _worker(work_queue):
             ls_remote_lines = subprocess.check_output(cmd).splitlines()
             for line in ls_remote_lines:
                 hash, ref = line.split('\t', 1)
-                if ref.endswith(freeze_version):
-                    if freeze_to_tag and ref.startswith('refs/tags/'):
-                        source_repo.version = ref.split('refs/tags/')[1]
-                    else:
-                        source_repo.version = hash
+                if ref == 'refs/tags/%s' % freeze_version and freeze_to_tag:
+                    source_repo.version = ref.split('refs/tags/')[1]
+                    break
+                elif ref == 'refs/heads/%s' % freeze_version or ref == 'refs/tags/%s' % freeze_version:
+                    source_repo.version = hash
                     break
 
             work_queue.task_done()

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -55,7 +55,7 @@ def test_get_index_from_http_with_query_parameters():
     else:
         proc = subprocess.Popen([sys.executable, '-m', 'http.server', '9876'],
                                 cwd=FILES_DIR)
-    time.sleep(0.1)
+    time.sleep(0.5)
     try:
         i = get_index(url)
         assert len(i.distributions.keys()) == 1


### PR DESCRIPTION
The previous logic would catch on a branch name like `fixup-to-1.1.0`, where this insists on a match.