### PR TITLE
SourceDependencyWalker, and cache updating

### DIFF
--- a/src/rosdistro/distribution.py
+++ b/src/rosdistro/distribution.py
@@ -34,6 +34,7 @@
 from .manifest_provider.bitbucket import bitbucket_manifest_provider
 from .manifest_provider.git import git_manifest_provider, git_source_manifest_provider
 from .manifest_provider.github import github_manifest_provider, github_source_manifest_provider
+from .package import Package
 
 
 class Distribution(object):

--- a/src/rosdistro/distribution_cache.py
+++ b/src/rosdistro/distribution_cache.py
@@ -33,7 +33,11 @@
 
 from __future__ import print_function
 
+from . import logger
 from .distribution_file import create_distribution_file
+from .package import Package
+from .vcs import Git, ref_is_hash
+import sys
 
 
 class DistributionCache(object):
@@ -60,6 +64,8 @@ class DistributionCache(object):
         self.distribution_file = create_distribution_file(name, self._distribution_file_data)
         self.release_package_xmls = data['release_package_xmls'] if data else {}
         self.source_repo_package_xmls = data['source_repo_package_xmls'] if data and 'source_repo_package_xmls' in data else {}
+
+        self.distribution_file.source_packages = self.get_source_packages()
 
         # if Python 2 has converted the xml to unicode, convert it back
         for k, v in self.release_package_xmls.items():
@@ -98,16 +104,64 @@ class DistributionCache(object):
         self._distribution_file_data = distribution_file_data
         dist_file = create_distribution_file(self.distribution_file.name, self._distribution_file_data)
 
-        # remove all package xmls if repository information has changed
+        # remove all release package xmls where the package version has changed.
+        print("- removing invalid release package cache entries.")
         for pkg_name in sorted(dist_file.release_packages.keys()):
             if pkg_name not in self.distribution_file.release_packages:
                 continue
             if pkg_name in self.release_package_xmls and self._get_repo_info(dist_file, pkg_name) != self._get_repo_info(self.distribution_file, pkg_name):
+                logger.debug("Dropping release package XML cache for %s" % pkg_name)
                 del self.release_package_xmls[pkg_name]
 
+        # Remove all source package xmls where the devel branch is pointing to a different commit than
+        # the one we have associated with our cache. This requires calling git ls-remote on all affected repos.
+        if self.source_repo_package_xmls:
+            print("- checking invalid source repo cache entries.")
+            for repo in sorted(self.source_repo_package_xmls.keys()):
+                sys.stdout.write('.')
+                sys.stdout.flush()
+                try:
+                    source_repository = dist_file.repositories[repo].source_repository
+                except (KeyError, AttributeError):
+                    # The repo entry has been dropped, or the source stanza from it has been dropped,
+                    # either way, remove the cache entries associated with this repository.
+                    logger.debug('Unable to find source repository info for repo "%s".' % repo)
+                    del self.source_repo_package_xmls[repo]
+                    continue
+
+                if ref_is_hash(source_repository.version):
+                    source_hash = source_repository.version
+                else:
+                    result = Git().command('ls-remote', source_repository.url, source_repository.version)
+                    if result['returncode'] != 0 or not result['output']:
+                        # Error checking remote, or unable to find remote reference. Drop the cache entry.
+                        logger.debug("Unable to check hash for branch %s of %s, dropping cache entry." % (source_repository.version, source_repository.url))
+                        del self.source_repo_package_xmls[repo]
+                        continue
+                    # Split by line first and take the last line, to squelch any preamble output, for example
+                    # a known host key validation notice.
+                    source_hash = result['output'].split('\n')[-1].split('\t')[0]
+
+                cached_hash = self.source_repo_package_xmls[repo]['_ref']
+                if source_hash != cached_hash:
+                    logger.debug('Repo "%s" has moved from %s to %s, dropping cache.' % (repo, cached_hash, source_hash))
+                    del self.source_repo_package_xmls[repo]
+            sys.stdout.write('\n')
+
         self.distribution_file = dist_file
+        self.distribution_file.source_packages = self.get_source_packages()
+
         # remove packages which are not in the new distribution file
         self._remove_obsolete_entries()
+
+    def get_source_packages(self):
+        """ Returns dictionary mapping source package names to Package() objects. """
+        package_dict = {}
+        for source_repo_name, source_repo in self.source_repo_package_xmls.items():
+            for pkg_name in source_repo:
+                if pkg_name[0] != '_':
+                    package_dict[pkg_name] = Package(pkg_name, source_repo_name)
+        return package_dict
 
     def _get_repo_info(self, dist_file, pkg_name):
         pkg = dist_file.release_packages[pkg_name]

--- a/src/rosdistro/distribution_file.py
+++ b/src/rosdistro/distribution_file.py
@@ -51,6 +51,7 @@ class DistributionFile(object):
 
         self.repositories = {}
         self.release_packages = {}
+        self.source_packages = {}
         if 'repositories' in data and data['repositories']:
             for repo_name in sorted(data['repositories'].keys()):
                 repo_data = data['repositories'][repo_name]

--- a/src/rosdistro/manifest_provider/git.py
+++ b/src/rosdistro/manifest_provider/git.py
@@ -39,10 +39,8 @@ import re
 import shutil
 import tempfile
 
-from rosdistro.vcs import Git
-
-
-workspace_base = '/tmp/rosdistro-workspace'
+from rosdistro import logger
+from rosdistro.vcs import Git, ref_is_hash
 
 
 def git_manifest_provider(_dist_name, repo, pkg_name):
@@ -87,7 +85,7 @@ def _temp_git_clone(url, ref):
     base = tempfile.mkdtemp('rosdistro')
     git = Git(cwd=base)
     try:
-        if git.version_gte('1.8.0') and not _ref_is_hash(ref):
+        if git.version_gte('1.8.0') and not ref_is_hash(ref):
             # Directly clone the required ref with least amount of additional history.
             # Available since git 1.8.0, but only works for tags and branches, not hashes:
             # https://git.kernel.org/cgit/git/git.git/tree/Documentation/git-clone.txt?h=v1.8.0#n158
@@ -107,7 +105,3 @@ def _temp_git_clone(url, ref):
         yield base
     finally:
         shutil.rmtree(base)
-
-
-def _ref_is_hash(ref):
-    return re.match('^[0-9a-f]{40}$', ref) is not None

--- a/src/rosdistro/vcs.py
+++ b/src/rosdistro/vcs.py
@@ -34,6 +34,7 @@
 
 from distutils.version import LooseVersion
 import os
+import re
 import subprocess
 
 
@@ -56,6 +57,10 @@ class Git(object):
             result = cls().command('--version')
             cls._client_version = result['output'].split()[-1]
         return LooseVersion(cls._client_version) >= LooseVersion(version)
+
+
+def ref_is_hash(ref):
+    return re.match('^[0-9a-f]{40}$', ref) != None
 
 
 def _run_command(cmd, cwd=None, env=None):


### PR DESCRIPTION
This is the final piece of the source manifest caching puzzle— the bit which exposes an easy tie-in for rosinstall_generator and similar tooling. This is a follow-on to the following previous PRs, which have all now been rebased for the following review/merge order:

- #79 <- Generalizing git command line functionality, added tests for manifest providers.
- #80 <- Cache size reduction.
- #78 <- Implement source manifest caching.

We've actually been running all of this in prod since early June, so what you're seeing here has some miles under it (barring any horrible mistakes in the rebasing and cherry-picking necessary to prepare these four updated sequential PRs).

For the diff of just this one: https://github.com/mikepurvis/rosdistro-1/compare/source-manifest-caching...mikepurvis:source-dep-resolution-pr

@dirk-thomas @tfoote