### PR TITLE
Enable github private repos.

### DIFF
--- a/src/rosdistro/loader.py
+++ b/src/rosdistro/loader.py
@@ -33,19 +33,46 @@
 
 import socket
 import time
+import os
+import sys
+import base64
+
+from . import logger
+
 try:
-    from urllib.request import urlopen
+    from urllib.request import urlopen, Request
     from urllib.error import HTTPError
     from urllib.error import URLError
 except ImportError:
-    from urllib2 import urlopen
+    from urllib2 import urlopen, Request
     from urllib2 import HTTPError
     from urllib2 import URLError
 
 
+GITHUB_USER = os.getenv('GITHUB_USER', None)
+GITHUB_PASSWORD = os.getenv('GITHUB_PASSWORD', None)
+
+
+def auth_header(username=None, password=None, token=None):
+    if username and password:
+        if sys.version_info > (3, 0):
+            userandpass = base64.b64encode(bytes('%s:%s' % (username, password), 'utf-8'))
+        else:
+            userandpass = base64.b64encode('%s:%s' % (username, password))
+        userandpass = userandpass.decode('ascii')
+        return 'Basic %s' % userandpass
+    elif token:
+        return 'token %s' % token
+
+
 def load_url(url, retry=2, retry_period=1, timeout=10, skip_decode=False):
+    req = Request(url)
+    if GITHUB_USER and GITHUB_PASSWORD:
+        logger.debug('- using http basic auth from supplied environment variables.')
+        authheader = auth_header(username=GITHUB_USER, password=GITHUB_PASSWORD)
+        req.add_header('Authorization', authheader)
     try:
-        fh = urlopen(url, timeout=timeout)
+        fh = urlopen(req, timeout=timeout)
     except HTTPError as e:
         if e.code in [500, 502, 503] and retry:
             time.sleep(retry_period)

--- a/src/rosdistro/manifest_provider/bitbucket.py
+++ b/src/rosdistro/manifest_provider/bitbucket.py
@@ -73,7 +73,7 @@ def bitbucket_manifest_provider(_dist_name, repo, pkg_name):
         req = Request(url)
         if BITBUCKET_USER and BITBUCKET_PASSWORD:
             logger.debug('- using http basic auth from supplied environment variables.')
-            authheader = 'Basic %s' % base64.b64encode('%s:%s' % (BITBUCKET_USER, BITBUCKET_PASSWORD))
+            authheader = 'Basic %s' % base64.b64encode(b'%s:%s' % (BITBUCKET_USER, BITBUCKET_PASSWORD))
             req.add_header('Authorization', authheader)
         package_xml = urlopen(req).read().decode('utf-8')
         return package_xml

--- a/src/rosdistro/manifest_provider/github.py
+++ b/src/rosdistro/manifest_provider/github.py
@@ -82,7 +82,7 @@ def github_source_manifest_provider(repo):
     req = Request(tree_url)
     if GITHUB_USER and GITHUB_PASSWORD:
         logger.debug('- using http basic auth from supplied environment variables.')
-        authheader = 'Basic %s' % base64.b64encode('%s:%s' % (GITHUB_USER, GITHUB_PASSWORD))
+        authheader = 'Basic %s' % base64.b64encode(b'%s:%s' % (GITHUB_USER, GITHUB_PASSWORD))
         req.add_header('Authorization', authheader)
     try:
         tree_json = json.loads(urlopen(req).read().decode('utf-8'))


### PR DESCRIPTION
Needs: https://github.com/ros-infrastructure/bloom/pull/429

> I'm making a private build farm, and I've seen a lot of people doing local clones and file:/// references for their ROS_DISTRO_URL and this was just so horribly clunky I fixed it.
> 
> This could probably be better intertwined with the .config/bloom settings. I had to set both the token in .config/bloom and GITHUB_PASSWORD to my github "Persontal Access Token" to get it to work.
>
> This also supports private automatic PR's from bloom!