### PR TITLE
set default Debian-Version

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,5 @@
 [rosdistro]
+Debian-Version: 100
 Depends: ca-certificates, python-argparse, python-rosdistro-modules, python-setuptools, python-yaml
 Depends3: ca-certificates, python3-rosdistro-modules, python3-setuptools, python3-yaml
 Conflicts: python3-rosdistro


### PR DESCRIPTION
Requires ros-infrastructure/ros_release_python#20.