### PR TITLE
Add retry on git remote

### DIFF
--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -121,9 +121,9 @@ def _worker(work_queue):
 
             work_queue.task_done()
 
-        except subprocess.CalledProcessError as err:
-            print("No information could be retrieved for repo %s with error: %s %s" %
-                 (source_repo.url, err, err.message), file=sys.stderr)
+        except subprocess.CalledProcessError as e:
+            print("No information could be retrieved for repo %s with error: %s" %
+                  (source_repo.url, e), file=sys.stderr)
             work_queue.task_done()
 
         except queue.Empty:

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -122,8 +122,8 @@ def _worker(work_queue):
             work_queue.task_done()
 
         except subprocess.CalledProcessError as e:
-            print("No information could be retrieved for repo %s with error: %s" %
-                  (source_repo.url, e), file=sys.stderr)
+            print("No information could be retrieved for repo %s with error: %s %s" %
+                  (source_repo.url, e, e.message), file=sys.stderr)
             work_queue.task_done()
 
         except queue.Empty:

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -83,7 +83,7 @@ def freeze_distribution_sources(dist, release_version=False, release_tag=False,
 
 
 # Get the repo commit information
-def _getRepoInfo(source_repo):
+def _get_repo_info(source_repo):
     count = 0
     # allow for a retry if the ls-remote fails to query the endpoint repo
     while True:
@@ -103,7 +103,7 @@ def _worker(work_queue):
     while True:
         try:
             source_repo, freeze_version, freeze_to_tag = work_queue.get(block=False)
-            ls_remote_lines = _getRepoInfo(source_repo)
+            ls_remote_lines = _get_repo_info(source_repo)
             for line in ls_remote_lines:
                 hash, ref = line.split('\t', 1)
                 if freeze_to_tag and ref == 'refs/tags/%s' % freeze_version:

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -83,22 +83,24 @@ def freeze_distribution_sources(dist, release_version=False, release_tag=False,
 
 
 # Get the repo commit information
-def _get_repo_info(source_repo):
-    count = 0
+def _get_repo_info(source_repo, retry_count=3, sleep_time=1):
+    count = 1
     # allow for a retry if the ls-remote fails to query the endpoint repo
     while True:
         try:
             cmd = ['git', 'ls-remote', source_repo.url]
             ls_remote_lines = subprocess.check_output(cmd).splitlines()
             return ls_remote_lines
-        except:
-            print("Non-zero return code for: %s retrying command" % ' '.join(cmd), file=sys.stderr)
+        except subprocess.CalledProcessError as err:
+            print("Non-zero return code for: %s, attempt %s of %s, sleeping for %s seconds and retrying command" %
+                 (' '.join(cmd), count, retry_count, sleep_time), file=sys.stderr)
             count += 1
-            # reraise the error if we've attempted 3 times
-            if count > 3:
+            # reraise the error if we've attempted retry_count times
+            if count > retry_count:
+                err.message += " - Attempted %s time(s)" % retry_count
                 raise
             # brief delay incase its an intermittent issue with infrastructure
-            time.sleep(1)
+            time.sleep(sleep_time)
 
 
 def _worker(work_queue):
@@ -117,8 +119,9 @@ def _worker(work_queue):
 
             work_queue.task_done()
 
-        except subprocess.CalledProcessError:
-            print("No information could be retrieved for repo %s" % source_repo.url)
+        except subprocess.CalledProcessError as err:
+            print("No information could be retrieved for repo %s with error: %s %s" %
+                 (source_repo.url, err, err.message))
             work_queue.task_done()
 
         except queue.Empty:

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -85,6 +85,8 @@ def freeze_distribution_sources(dist, release_version=False, release_tag=False,
 # Get the repo commit information
 def _get_repo_info(source_repo, retry_count=3, sleep_time=1):
     count = 1
+    # increase retry count to handle initial call
+    retry_count += 1
     # allow for a retry if the ls-remote fails to query the endpoint repo
     while True:
         try:
@@ -121,7 +123,7 @@ def _worker(work_queue):
 
         except subprocess.CalledProcessError as err:
             print("No information could be retrieved for repo %s with error: %s %s" %
-                 (source_repo.url, err, err.message))
+                 (source_repo.url, err, err.message), file=sys.stderr)
             work_queue.task_done()
 
         except queue.Empty:

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -97,6 +97,8 @@ def _get_repo_info(source_repo):
             # reraise the error if we've attempted 3 times
             if count > 3:
                 raise
+            # brief delay incase its an intermittent issue with infrastructure
+            time.sleep(1)
 
 
 def _worker(work_queue):


### PR DESCRIPTION
We have seen some intermittent issues with ls-remote calls which cause the version not to be frozen.
Introducing a retry on the git ls-remote call if it fails the first time to handle these intermittent connection problems.