### PR TITLE
fix sanitize function to collapse empty tags

### DIFF
--- a/src/rosdistro/manifest_provider/cache.py
+++ b/src/rosdistro/manifest_provider/cache.py
@@ -42,17 +42,21 @@ def sanitize_xml(xml_string):
     so str (Python 2) or bytes (Python 3).
     """
     def _squash(node):
-        drop_nodes = []
-        for x in node.childNodes:
+        # remove comment nodes
+        for x in list(node.childNodes):
+            if x.nodeType is minidom.Node.COMMENT_NODE:
+                node.removeChild(x)
+        # minimize whitespaces, remove empty text nodes
+        for x in list(node.childNodes):
             if x.nodeType == minidom.Node.TEXT_NODE:
                 if x.nodeValue:
                     x.nodeValue = ' '.join(x.nodeValue.strip().split())
-            elif x.nodeType == minidom.Node.ELEMENT_NODE:
+                if not x.nodeValue:
+                    node.removeChild(x)
+        # process all tags recusively
+        for x in node.childNodes:
+            if x.nodeType == minidom.Node.ELEMENT_NODE:
                 _squash(x)
-            elif x.nodeType is minidom.Node.COMMENT_NODE:
-                drop_nodes.append(x)
-        for x in drop_nodes:
-            node.removeChild(x)
         return node
     try:
         # Python 2. The minidom module parses as ascii, so we have to pre-encode.

--- a/test/test_manifest_providers.py
+++ b/test/test_manifest_providers.py
@@ -106,10 +106,13 @@ def test_git_source_multi():
 
 def test_sanitize():
     assert '<a>abc</a>' in sanitize_xml('<a>ab<!-- comment -->c</a>')
-    assert '<a><b></b><c>ab c</c></a>' in sanitize_xml('<a><b> </b>  <c>  ab  c  </c></a>')
+    assert '<a><b/><c>ab c</c></a>' in sanitize_xml('<a><b> </b>  <c>  ab  c  </c></a>')
 
     # This unicode check should be valid on both Python 2 and 3.
     assert '<a>français</a>' in sanitize_xml('<a> français  </a>')
+
+    # subsequent parse calls will collapse empty tags, therefore sanitize should do the same
+    assert '<a><empty/></a>' in sanitize_xml('<a> <empty> <!-- comment --> </empty> </a>')
 
 
 def _genmsg_release_repo():


### PR DESCRIPTION
Fixes ros-infrastructure/ros_buildfarm#497.

Currently the sanitize function doesn't remove empty text nodes. As a consequence tags which are empty but contain a text node with no content are not collapsed.

As a consequence the xml fetched and stored in the cache in the first time doesn't stay the same when it is being reloaded from the cache and parsed again. The second parse will collapse the empty tags which makes the xml not equal.