### PR TITLE
Add new SourceRepositoryCache class.

### DIFF
--- a/src/rosdistro/manifest_provider/git.py
+++ b/src/rosdistro/manifest_provider/git.py
@@ -40,6 +40,7 @@ from contextlib import contextmanager
 from catkin_pkg.package import InvalidPackage, parse_package_string
 from catkin_pkg.packages import find_package_paths
 
+from rosdistro.source_repository_cache import SourceRepositoryCache
 from rosdistro.vcs import Git, ref_is_hash
 
 
@@ -61,8 +62,8 @@ def git_source_manifest_provider(repo):
     try:
         with _temp_git_clone(repo.url, repo.version) as git_repo_path:
             # Include the git hash in our cache dictionary.
-            result = Git(git_repo_path).command('rev-parse', 'HEAD')
-            cache = {'_ref': result['output']}
+            git_hash = Git(git_repo_path).command('rev-parse', 'HEAD')['output']
+            cache = SourceRepositoryCache.from_ref(git_hash)
 
             # Find package.xml files inside the repo.
             for package_path in find_package_paths(git_repo_path):
@@ -74,7 +75,7 @@ def git_source_manifest_provider(repo):
                     name = parse_package_string(package_xml).name
                 except InvalidPackage:
                     raise RuntimeError('Unable to parse package.xml file found in %s' % repo.url)
-                cache[name] = [package_path, package_xml]
+                cache.add(name, package_path, package_xml)
 
     except Exception as e:
         raise RuntimeError('Unable to fetch source package.xml files: %s' % e)

--- a/src/rosdistro/manifest_provider/github.py
+++ b/src/rosdistro/manifest_provider/github.py
@@ -44,6 +44,7 @@ import os
 
 from catkin_pkg.package import parse_package_string
 
+from rosdistro.source_repository_cache import SourceRepositoryCache
 from rosdistro import logger
 
 GITHUB_USER = os.getenv('GITHUB_USER', None)
@@ -112,13 +113,13 @@ def github_source_manifest_provider(repo):
                 return True
     package_xml_paths = list(filter(package_xml_in_parent, package_xml_paths))
 
-    cache = {'_ref': tree_json['sha']}
+    cache = SourceRepositoryCache.from_ref(tree_json['sha'])
     for package_xml_path in package_xml_paths:
         url = 'https://raw.githubusercontent.com/%s/%s/%s' % \
-            (path, cache['_ref'], package_xml_path + '/package.xml' if package_xml_path else 'package.xml')
+            (path, cache.ref(), package_xml_path + '/package.xml' if package_xml_path else 'package.xml')
         logger.debug('- load package.xml from %s' % url)
         package_xml = _get_url_contents(url)
         name = parse_package_string(package_xml).name
-        cache[name] = [package_xml_path, package_xml]
+        cache.add(name, package_xml_path, package_xml)
 
     return cache

--- a/src/rosdistro/source_repository_cache.py
+++ b/src/rosdistro/source_repository_cache.py
@@ -77,7 +77,7 @@ class SourceRepositoryCache(object):
         path to package relative to repo root, and string of package xml.
         """ 
         if package_name not in self._package_names:
-            raise KeyError("Package %s not present in SourceRepositoryCache." % package_name)
+            raise KeyError("Package '%s' not present in SourceRepositoryCache." % package_name)
         return self._data[package_name]
 
     def __len__(self):

--- a/src/rosdistro/source_repository_cache.py
+++ b/src/rosdistro/source_repository_cache.py
@@ -1,0 +1,99 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2018, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+class SourceRepositoryCache(object):
+    """
+    This class represents a cache of the package XML strings for all packages in a single
+    repo at a particular moment in time. A dictionary of many of these (one for each repo)
+    keyed to the repo name represents the totality of the source package xml cache.
+    """
+
+    def __init__(self, data):
+        assert data
+        self._ref = data['_ref']
+        self._package_names = set([name for name in data.keys() if name != '_ref'])
+        self._data = data
+
+    def get_data(self):
+        """
+        Return the bare data dict, suitable for serializing into yaml.
+        """
+        return self._data
+
+    @classmethod
+    def from_ref(cls, ref):
+        """
+        Create a new empty cache instance from just the version control reference hash.
+        """
+        return cls({'_ref': ref})
+
+    def add(self, package_name, package_path, package_xml_string):
+        """
+        Add a package to the cache.
+        """
+        self._data[package_name] = (package_path, package_xml_string)
+        self._package_names.add(package_name)
+
+    def __iter__(self):
+        """
+        Iterate the list of package names in this cached repo. Returns an iterator of str.
+        """
+        return iter(self._package_names)
+
+    def __getitem__(self, package_name):
+        """
+        Access the cached information about a specific package. Returns a (str, str) of
+        path to package relative to repo root, and string of package xml.
+        """ 
+        if package_name not in self._package_names:
+            raise KeyError("Package %s not present in SourceRepositoryCache." % package_name)
+        return self._data[package_name]
+
+    def __len__(self):
+        """
+        Returns the number of packages in this repo.
+        """
+        return len(self._package_names)
+
+    def keys(self):
+        """
+        Return the list of packages in the repo cache.
+        """
+        return self._package_names
+
+    def ref(self):
+        """
+        Return the version control hash.
+        """
+        return self._ref

--- a/test/test_manifest_providers.py
+++ b/test/test_manifest_providers.py
@@ -43,7 +43,7 @@ def test_git_source():
     repo_cache = git_source_manifest_provider(_genmsg_source_repo())
 
     # This hash corresponds to the 0.5.7 tag.
-    assert repo_cache['_ref'] == '81b66fe5eb00043c43894ddeee07e738d9b9712f'
+    assert repo_cache.ref() == '81b66fe5eb00043c43894ddeee07e738d9b9712f'
 
     package_path, package_xml = repo_cache['genmsg']
     assert '' == package_path
@@ -90,7 +90,7 @@ def test_github_source():
     repo_cache = rosdistro.manifest_provider.github.github_source_manifest_provider(_genmsg_source_repo())
 
     # This hash corresponds to the 0.5.7 tag.
-    assert repo_cache['_ref'] == '81b66fe5eb00043c43894ddeee07e738d9b9712f'
+    assert repo_cache.ref() == '81b66fe5eb00043c43894ddeee07e738d9b9712f'
 
     package_path, package_xml = repo_cache['genmsg']
     assert '' == package_path
@@ -99,7 +99,7 @@ def test_github_source():
 
 def test_git_source_multi():
     repo_cache = git_source_manifest_provider(_ros_source_repo())
-    assert repo_cache['_ref']
+    assert repo_cache.ref()
     package_path, package_xml = repo_cache['roslib']
     assert package_path == 'core/roslib'
 


### PR DESCRIPTION
Addresses #116.

Testing was by rebuilding caches of my [toy rosdistro](https://github.com/mikepurvis/rosdistro-minimal) with and without the `--include-source` option, and with and without `--preclean`.

On the consumption side, I checked that `rosinstall_generator` still does the right thing with and without `--upstream-development` and against caches which do and do not have a source cache included.