### PR TITLE
Fix source cache issue.

### DIFF
--- a/src/rosdistro/manifest_provider/cache.py
+++ b/src/rosdistro/manifest_provider/cache.py
@@ -130,13 +130,14 @@ class CachedSourceManifestProvider(object):
             logger.debug('Load package XMLs for repo "%s" from cache' % repo.name)
 
         # De-duplicate with the release package XMLs. This will cause the YAML writer
-        # to use references, saving a lot of space in the cache file.
-        for key in repo_cache or {}:
-            if key[0] != '_':
-                repo_cache[key][1] = sanitize_xml(repo_cache[key][1])
-                if key in self._distribution_cache.release_package_xmls:
-                    release_package_xml = self._distribution_cache.release_package_xmls[key]
-                    if repo_cache[key][1] == release_package_xml:
-                        repo_cache[key][1] = release_package_xml
+        # to use references for the common strings, saving a lot of space in the cache file.
+        if repo_cache:
+            for package_name, package_path, package_xml in repo_cache.items():
+                package_xml = sanitize_xml(package_xml)
+                release_package_xml = self._distribution_cache.release_package_xmls.get(package_name, None)
+                if package_xml == release_package_xml:
+                    # Re-add to the cache with a reference to the "release" instance of the string, so that
+                    # the YAML writer is able to notice that the same object appears multiple times.
+                    repo_cache.add(package_name, package_path, release_package_xml)
 
         return repo_cache

--- a/src/rosdistro/manifest_provider/cache.py
+++ b/src/rosdistro/manifest_provider/cache.py
@@ -136,8 +136,7 @@ class CachedSourceManifestProvider(object):
                 package_xml = sanitize_xml(package_xml)
                 release_package_xml = self._distribution_cache.release_package_xmls.get(package_name, None)
                 if package_xml == release_package_xml:
-                    # Re-add to the cache with a reference to the "release" instance of the string, so that
-                    # the YAML writer is able to notice that the same object appears multiple times.
-                    repo_cache.add(package_name, package_path, release_package_xml)
+                    package_xml = release_package_xml
+                repo_cache.add(package_name, package_path, package_xml)
 
         return repo_cache

--- a/src/rosdistro/source_repository_cache.py
+++ b/src/rosdistro/source_repository_cache.py
@@ -80,6 +80,15 @@ class SourceRepositoryCache(object):
             raise KeyError("Package '%s' not present in SourceRepositoryCache." % package_name)
         return self._data[package_name]
 
+    def items(self):
+        """
+        Generator of (str, str, str) containing the package name, path relative
+        to repo root, and package xml string.
+        """
+        for package_name in self._package_names:
+            package_path, package_xml_string = self._data[package_name]
+            yield package_name, package_path, package_xml_string
+
     def __len__(self):
         """
         Returns the number of packages in this repo.


### PR DESCRIPTION
Follow up to #117; corrects an issue which came up for us when rolling out 0.6.7 to our build system. The problem manifests in cases where the cache is generated twice in a row and therefore an individual repo's cache is not updated.

Waiting on a 👍 from @tspicer01 who will confirm this corrects the issue when rosdistro is run from source.

We can continue to run 0.6.6 on our infrastructure in the short term (to generate the cache), but 0.6.7 will still fix the consumption side for users. So this is not a critical fix.