### PR TITLE
use version number on -modules dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ from setuptools import find_packages, setup
 
 kwargs = {
     'name': 'rosdistro',
-    'version': '0.6.8',  # same version as in src/rosdistro/__init__.py
+    # same version as in:
+    # - src/rosdistro/__init__.py
+    # - stdeb.cfg
+    'version': '0.6.8',
     'install_requires': ['PyYAML', 'setuptools'],
     'packages': find_packages('src'),
     'package_dir': {'': 'src'},

--- a/src/rosdistro/__init__.py
+++ b/src/rosdistro/__init__.py
@@ -58,7 +58,10 @@ from .loader import load_url  # noqa
 from .manifest_provider.cache import CachedManifestProvider, CachedSourceManifestProvider  # noqa
 
 
-__version__ = '0.6.8'  # same version as in setup.py
+# same version as in:
+# - setup.py
+# - stdeb.cfg
+__version__ = '0.6.8'
 
 # index information
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,13 @@
 [rosdistro]
 Debian-Version: 100
-Depends: ca-certificates, python-argparse, python-rosdistro-modules, python-setuptools, python-yaml
-Depends3: ca-certificates, python3-rosdistro-modules, python3-setuptools, python3-yaml
+; rosdistro-modules same version as in:
+; - setup.py
+; - src/rosdistro/__init__.py
+Depends: ca-certificates, python-argparse, python-rosdistro-modules (>= 0.6.8), python-setuptools, python-yaml
+; rosdistro-modules same version as in:
+; - setup.py
+; - src/rosdistro/__init__.py
+Depends3: ca-certificates, python3-rosdistro-modules (>= 0.6.8), python3-setuptools, python3-yaml
 Conflicts: python3-rosdistro
 Conflicts3: python-rosdistro
 Copyright-File: LICENSE.txt


### PR DESCRIPTION
Use the version number on the dependency on the `-modules` package to ensure that the `-modules` package gets updated too.

This will address the problem described in https://answers.ros.org/question/245967/importerror-no-module-named-rospkg-python3/

The same patch will be necessary for `catkin_pkg`, `rospkg` and `ros_buildfarm`.