### PR TITLE
remove Ubuntu distros older than Trusty, remove Debian Wheezy

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ Depends3: ca-certificates, python3-rosdistro-modules (>= 0.6.9), python3-setupto
 Conflicts: python3-rosdistro
 Conflicts3: python-rosdistro
 Copyright-File: LICENSE.txt
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -23,6 +23,6 @@ Conflicts3: python3-rosdistro (<< 0.6.0)
 Replaces: python-rosdistro (<< 0.6.0)
 Replaces3: python3-rosdistro (<< 0.6.0)
 Copyright-File: LICENSE.txt
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Related to ros-infrastructure/catkin_pkg#232.

Basically the toolchain on Bionic embeds a Python dependency on version >= 2.7.5 which isn't available on Ubuntu Precise / Debian Wheezy. At the same time it removes other EOL Ubuntu distro before the last supported LTS which is currently Ubuntu Trusty.