### PR TITLE
Version match check made less restrictive

### DIFF
--- a/src/rosdistro/distribution_cache_generator.py
+++ b/src/rosdistro/distribution_cache_generator.py
@@ -107,7 +107,7 @@ def generate_distribution_cache(index, dist_name, preclean=False, ignore_local=F
             errors.append('%s: invalid package.xml file for package "%s": %s' % (dist_name, pkg_name, e))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s-[\dA-z~\+\.]+$' % re.escape(pkg.version), repo.version):
+        if not re.match('^%s[-\dA-z~\+\.]*$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
         if package_xml != old_package_xml:

--- a/src/rosdistro/distribution_cache_generator.py
+++ b/src/rosdistro/distribution_cache_generator.py
@@ -107,7 +107,7 @@ def generate_distribution_cache(index, dist_name, preclean=False, ignore_local=F
             errors.append('%s: invalid package.xml file for package "%s": %s' % (dist_name, pkg_name, e))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s[-\dA-z~\+\.]*$' % re.escape(pkg.version), repo.version):
+        if not re.match('^%s(-[\dA-z~\+\.]+)?$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
         if package_xml != old_package_xml:

--- a/src/rosdistro/release_cache_generator.py
+++ b/src/rosdistro/release_cache_generator.py
@@ -96,7 +96,7 @@ def generate_release_cache(index, dist_name, preclean=False, debug=False):
             errors.append('%s: invalid package.xml file for package "%s"' % (dist_name, pkg_name))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s-[\dA-z~\+\.]+$' % re.escape(pkg.version), repo.version):
+        if not re.match('^%s(-[\dA-z~\+\.]+)?$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
     if not debug:


### PR DESCRIPTION
Lossign the regex in order to also accept versions that do not contain
the "-X" suffix. This will match both "version" and "version-X".

Our use case: we do releases without the "-X suffix" which we think is a reasonable convention. 