### PR TITLE
Git manifest provider support for one repo multiple packages

### DIFF
--- a/src/rosdistro/manifest_provider/git.py
+++ b/src/rosdistro/manifest_provider/git.py
@@ -51,7 +51,11 @@ def git_manifest_provider(_dist_name, repo, pkg_name):
         with _temp_git_clone(repo.url, release_tag) as git_repo_path:
             filename = os.path.join(git_repo_path, 'package.xml')
             if not os.path.exists(filename):
-                raise RuntimeError('Could not find package.xml in repository "%s"' % repo.url)
+                # Try appending package name to repo path to handle case where there are multiple packages in a single
+                # repo
+                filename = os.path.join(git_repo_path, pkg_name, 'package.xml')
+                if not os.path.exists(filename):
+                    raise RuntimeError('Could not find package.xml in repository "%s"' % repo.url)
             with open(filename, 'r') as f:
                 return f.read()
     except Exception as e:


### PR DESCRIPTION
Adds supports for packages like [ros-navigation](https://github.com/ros-planning/navigation) where there are multiple packages in one repo. In line with PR #126, there is a use case where the source repository can also be the release repository. This implies getting the manifest from a subfolder rather than from the root.

The PR sets the default behavior as of today and in case of failure will check in the subfolder. If not, will throw the exception as expected.