### PR TITLE
github.py:  encode('utf-8') package XML before parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ deb_dist
 dist
 *.pyc
 rosdistro.egg-info
+
+# nosetests artifacts
+/.coverage
+/nosetests.xml

--- a/src/rosdistro/manifest_provider/github.py
+++ b/src/rosdistro/manifest_provider/github.py
@@ -119,7 +119,7 @@ def github_source_manifest_provider(repo):
             (path, cache.ref(), package_xml_path + '/package.xml' if package_xml_path else 'package.xml')
         logger.debug('- load package.xml from %s' % url)
         package_xml = _get_url_contents(url)
-        name = parse_package_string(package_xml).name
+        name = parse_package_string(package_xml.encode('utf-8')).name
         cache.add(name, package_xml_path, package_xml)
 
     return cache

--- a/test/github-genmsg-package.xml
+++ b/test/github-genmsg-package.xml
@@ -6,6 +6,7 @@
     Standalone Python library for generating ROS message and service data structures for various languages.
   </description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="bogus@example.com">Bögus Umlaut User</maintainer>
   <license>BSD</license>
 
   <url type="website">http://www.ros.org/wiki/genmsg</url>

--- a/test/test_manifest_providers.py
+++ b/test/test_manifest_providers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import mock
+import sys
 
 import rosdistro.manifest_provider.github
 import rosdistro.vcs
@@ -81,6 +82,11 @@ def mock_get_url_contents(req):
 
     with open(fname, 'r') as infp:
         data = infp.read()
+
+    # Decode string, as done in
+    # rosdistro.manifest_provider.github._get_url_contents()
+    if sys.version_info[0] == 2:
+        data = data.decode('utf-8')
 
     return data
 


### PR DESCRIPTION
The `_get_url_contents()` function decodes downloaded content before
returning it.

The `github_source_manifest_provider()` function calls
`package.parse_package_string()` on this content, which passes it to
`xml.dom.minidom.parseString()`.  That expects input to be encoded.

This patch encodes that content before sending it out to
`package.parse_package_string()`.