### PR TITLE
Sync dep_type with catkin_pkg/package.py to allow more query types

### DIFF
--- a/src/rosdistro/dependency_walker.py
+++ b/src/rosdistro/dependency_walker.py
@@ -118,10 +118,14 @@ class DependencyWalker(object):
     def _get_dependencies(self, pkg_name, dep_type):
         pkg = self._get_package(pkg_name)
         deps = {
-            'buildtool': pkg.buildtool_depends,
             'build': pkg.build_depends,
+            'buildtool': pkg.buildtool_depends,
+            'build_export': pkg.build_export_depends,
+            'buildtool_export': pkg.buildtool_export_depends,
+            'exec': pkg.exec_depends,
             'run': pkg.run_depends,
-            'test': pkg.test_depends
+            'test': pkg.test_depends,
+            'doc': pkg.doc_depends,
         }
         return set([d.name for d in deps[dep_type]])
 


### PR DESCRIPTION
  * https://github.com/ros-infrastructure/catkin_pkg/blob/master/src/catkin_pkg/package.py#L273
  * To be used by superflore as in https://discourse.ros.org/t/a-proposal-for-a-superflore-oe-recipe-generation-scheme/8401