### PR TITLE
Add cosmic, disco, and eoan suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ Depends3: ca-certificates, python3-rosdistro-modules (>= 0.7.4), python3-setupto
 Conflicts: python3-rosdistro
 Conflicts3: python-rosdistro
 Copyright-File: LICENSE.txt
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful cosmic disco eoan bionic jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -23,6 +23,6 @@ Conflicts3: python3-rosdistro (<< 0.6.0)
 Replaces: python-rosdistro (<< 0.6.0)
 Replaces3: python3-rosdistro (<< 0.6.0)
 Copyright-File: LICENSE.txt
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ Depends3: ca-certificates, python3-rosdistro-modules (>= 0.7.4), python3-setupto
 Conflicts: python3-rosdistro
 Conflicts3: python-rosdistro
 Copyright-File: LICENSE.txt
-Suite: trusty utopic vivid wily xenial yakkety zesty artful cosmic disco eoan bionic jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 


### PR DESCRIPTION
These are now live on the ROS bootstrap repository and future releases should be pushed to them as well.