### PR TITLE
add Python 3.7 and 3.8 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 # command to install dependencies
 install:
 # develop seems to be required by travis since 02/2013


### PR DESCRIPTION
Since Debian Buster uses Python 3.7 and Ubuntu Focal targets Python 3.8.