### PR TITLE
Support tar sources and releases

### DIFF
--- a/src/rosdistro/distribution.py
+++ b/src/rosdistro/distribution.py
@@ -34,13 +34,14 @@
 from .manifest_provider.bitbucket import bitbucket_manifest_provider
 from .manifest_provider.git import git_manifest_provider, git_source_manifest_provider
 from .manifest_provider.github import github_manifest_provider, github_source_manifest_provider
+from .manifest_provider.tar import tar_manifest_provider, tar_source_manifest_provider
 from .package import Package
 
 
 class Distribution(object):
 
-    default_manifest_providers = [github_manifest_provider, bitbucket_manifest_provider, git_manifest_provider]
-    default_source_manifest_providers = [github_source_manifest_provider, git_source_manifest_provider]
+    default_manifest_providers = [github_manifest_provider, bitbucket_manifest_provider, git_manifest_provider, tar_manifest_provider]
+    default_source_manifest_providers = [github_source_manifest_provider, git_source_manifest_provider, tar_source_manifest_provider]
 
     def __init__(self, distribution_file, manifest_providers=None, source_manifest_providers=None):
         self._distribution_file = distribution_file

--- a/src/rosdistro/manifest_provider/tar.py
+++ b/src/rosdistro/manifest_provider/tar.py
@@ -1,0 +1,122 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020, Canonical Ltd.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Canonical Ltd. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import base64
+import io
+import os
+import shutil
+import tarfile
+import tempfile
+import urllib
+
+try:
+    from urllib.request import urlopen, Request
+except ImportError:
+    from urllib2 import urlopen, Request
+
+from catkin_pkg.package import InvalidPackage, parse_package_string
+from catkin_pkg.packages import find_package_paths
+
+from rosdistro.source_repository_cache import SourceRepositoryCache
+from rosdistro import logger
+
+_TAR_USER = os.getenv('TAR_USER', None)
+_TAR_PASSWORD = os.getenv('TAR_PASSWORD', None)
+
+def tar_manifest_provider(_dist_name, repo, pkg_name):
+    assert repo.type == 'tar'
+
+    subdir = repo.get_release_tag(pkg_name)
+
+    request = Request(repo.url)
+    if _TAR_USER and _TAR_PASSWORD:
+        logger.debug('- using http basic auth from supplied environment variables.')
+        authheader = 'Basic %s' % base64.b64encode('%s:%s' % (_TAR_USER, _TAR_PASSWORD))
+        request.add_header('Authorization', authheader)
+    elif _TAR_PASSWORD:
+        logger.debug('- using private token auth from supplied environment variables.')
+        request.add_header('Private-Token', _TAR_PASSWORD)
+
+    response = urlopen(request)
+    with tarfile.open(fileobj=io.BytesIO(response.read())) as tar:
+        package_xml = tar.extractfile(os.path.join(subdir, 'package.xml')).read()
+
+        # Python2 returns strings, Python3 returns bytes-- support both
+        try:
+            return package_xml.decode('utf-8')
+        except AttributeError:
+            return package_xml
+
+
+def tar_source_manifest_provider(repo):
+    assert repo.type == 'tar'
+
+    try:
+        request = Request(repo.url)
+        if _TAR_USER and _TAR_PASSWORD:
+            logger.debug('- using http basic auth from supplied environment variables.')
+            authheader = 'Basic %s' % base64.b64encode('%s:%s' % (_TAR_USER, _TAR_PASSWORD))
+            request.add_header('Authorization', authheader)
+        elif _TAR_PASSWORD:
+            logger.debug('- using private token auth from supplied environment variables.')
+            request.add_header('Private-Token', _TAR_PASSWORD)
+
+        response = urlopen(request)
+        with tarfile.open(fileobj=io.BytesIO(response.read())) as tar:
+            tmpdir = tempfile.mkdtemp()
+            try:
+                # Extract just the package.xmls
+                tar.extractall(path=tmpdir, members=_package_xml_members(tar))
+                cache = SourceRepositoryCache.from_ref(None)
+
+                for package_path in find_package_paths(tmpdir):
+                    if package_path == '.':
+                        package_path = ''
+                    with open(os.path.join(tmpdir, package_path, 'package.xml'), 'r') as f:
+                        package_xml = f.read()
+                    try:
+                        name = parse_package_string(package_xml).name
+                    except InvalidPackage:
+                        raise RuntimeError('Unable to parse package.xml file found in %s' % repo.url)
+                    cache.add(name, package_path, package_xml)
+
+                return cache
+            finally:
+                shutil.rmtree(tmpdir)
+    except Exception as e:
+        raise RuntimeError('Unable to fetch source package.xml files: %s' % e)
+
+
+def _package_xml_members(tar):
+    for tarinfo in tar:
+        if os.path.basename(tarinfo.name) == "package.xml":
+            yield tarinfo

--- a/src/rosdistro/release_repository_specification.py
+++ b/src/rosdistro/release_repository_specification.py
@@ -38,7 +38,7 @@ class ReleaseRepositorySpecification(RepositorySpecification):
 
     def __init__(self, name, data):
         super(ReleaseRepositorySpecification, self).__init__(name, data)
-        assert self.type == 'git'
+        assert self.type in ('git', 'tar')
 
         self.tags = {}
         if self.version is not None:

--- a/test/test_manifest_providers.py
+++ b/test/test_manifest_providers.py
@@ -39,6 +39,10 @@ def test_github():
     assert '</package>' in rosdistro.manifest_provider.github.github_manifest_provider('melodic', _genmsg_release_repo(), 'genmsg')
 
 
+def test_tar():
+    assert '</package>' in rosdistro.manifest_provider.tar.tar_manifest_provider('melodic', _genmsg_release_tarball(), 'genmsg')
+
+
 def test_git_source():
     repo_cache = git_source_manifest_provider(_genmsg_source_repo())
 
@@ -48,6 +52,7 @@ def test_git_source():
     package_path, package_xml = repo_cache['genmsg']
     assert '' == package_path
     assert '<version>0.5.11</version>' in package_xml
+
 
 # mock_get_url_contents is used to mock out the '_get_url_contents' method in
 # the rosdistro.manifest_provider.github module.  Instead of going out to github
@@ -104,6 +109,16 @@ def test_git_source_multi():
     assert package_path == 'core/roslib'
 
 
+def test_tar_source():
+    repo_cache = rosdistro.manifest_provider.tar.tar_source_manifest_provider(_genmsg_source_tarball())
+
+    assert repo_cache.ref() is None
+
+    package_path, package_xml = repo_cache['genmsg']
+    assert 'genmsg-0.5.16' == package_path
+    assert '<version>0.5.16</version>' in package_xml
+
+
 def test_sanitize():
     assert '<a>abc</a>' in sanitize_xml('<a>ab<!-- comment -->c</a>')
     assert '<a><b/><c>ab c</c></a>' in sanitize_xml('<a><b> </b>  <c>  ab  c  </c></a>')
@@ -123,10 +138,26 @@ def _genmsg_release_repo():
     })
 
 
+def _genmsg_release_tarball():
+    return ReleaseRepositorySpecification('genmsg', {
+        'url': 'https://github.com/ros-gbp/genmsg-release/archive/release/melodic/genmsg/0.5.16-1.tar.gz',
+        'tags': {'release': '{package}-release-release-melodic-{package}-{version}'},
+        'version': '0.5.16-1',
+        'type': 'tar'
+    })
+
+
 def _genmsg_source_repo():
     return SourceRepositorySpecification('genmsg', {
         'url': 'https://github.com/ros/genmsg.git',
         'version': '0.5.11'
+    })
+
+
+def _genmsg_source_tarball():
+    return SourceRepositorySpecification('genmsg', {
+        'url': 'https://github.com/ros/genmsg/archive/0.5.16.tar.gz',
+        'type': 'tar'
     })
 
 


### PR DESCRIPTION
Both the `distribution.yaml` and rosinstall files support non-git sources. However, rosdistro currently only supports building caches using git repositories. Add support for tarfiles as well.