### PR TITLE
pin pyparsing 2.4.7 for Python 2.7 and 3.4 and PyYAML for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - python setup.py build develop
   # newer versions of docutils dropped support for Python 3.4
   - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install docutils==0.15.2; fi
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi
   - pip install PyYAML argparse catkin_pkg rospkg setuptools
   - pip install nose coverage mock
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ python:
   - "3.8"
 # command to install dependencies
 install:
+  - if [ $TRAVIS_PYTHON_VERSION == "2.7" -o $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install pyparsing==2.4.7; fi
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi
 # develop seems to be required by travis since 02/2013
   - python setup.py build develop
   # newer versions of docutils dropped support for Python 3.4
   - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install docutils==0.15.2; fi
-  - if [ $TRAVIS_PYTHON_VERSION == "2.7" -o $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install pyparsing==2.4.7; fi
-  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi
   - pip install PyYAML argparse catkin_pkg rospkg setuptools
   - pip install nose coverage mock
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - python setup.py build develop
   # newer versions of docutils dropped support for Python 3.4
   - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install docutils==0.15.2; fi
+  - if [ $TRAVIS_PYTHON_VERSION == "2.7" -o $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install pyparsing==2.4.7; fi
   - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi
   - pip install PyYAML argparse catkin_pkg rospkg setuptools
   - pip install nose coverage mock


### PR DESCRIPTION
Fix CI failure with Python 3.4 since newer versions of `PyYAML` don't support Python 3.4 anymore.