### PR TITLE
[Windows] Explicit to use utf-8 to write cache yaml.

### DIFF
--- a/scripts/rosdistro_build_cache
+++ b/scripts/rosdistro_build_cache
@@ -94,7 +94,7 @@ def main():
         # write the cache
         data = yaml.dump(cache.get_data(), Dumper=CacheYamlDumper)
 
-        with open('%s-cache.yaml' % dist_name, 'w') as f:
+        with open('%s-cache.yaml' % dist_name, 'w', encoding='utf-8') as f:
             print('- write cache file "%s-cache.yaml"' % dist_name)
             f.write(data)
         with gzip.open('%s-cache.yaml.gz' % dist_name, 'wb') as f:


### PR DESCRIPTION
On some platforms (e.g., Windows), the system encoding depends on the system locale, and it is possible not `UTF-8` by default. And in such case, an error could occur when writing to the final cache YAML:

```
Traceback (most recent call last):
  File "c:\opt\ros\noetic\x64\Scripts\rosdistro_build_cache", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "C:\workspace\sa\rosdistro\scripts\rosdistro_build_cache", line 111, in <module>
    main()
  File "C:\workspace\sa\rosdistro\scripts\rosdistro_build_cache", line 99, in main
    f.write(data)
  File "encodings\cp1252.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode character '\u0142' in position 1073398: character maps to <undefined>
```

One can workaround the issue by setting `PYTHONUTF8=1` environment variable to ask Python behave differently.

Or we can be explicit to use such encoding when opening the file, since the data is already `UTF-8` encoded. And this is what proposed in this pull request.