### PR TITLE
Update release distributions.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,8 +11,8 @@ Depends3: ca-certificates, python3-rosdistro-modules (>= 0.8.3), python3-setupto
 Conflicts: python3-rosdistro
 Conflicts3: python-rosdistro
 Copyright-File: LICENSE.txt
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic cosmic disco eoan buster
+Suite3: bionic cosmic disco eoan focal jammy buster bullseye
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
@@ -25,8 +25,8 @@ Conflicts3: python3-rosdistro (<< 0.6.0)
 Replaces: python-rosdistro (<< 0.6.0)
 Replaces3: python3-rosdistro (<< 0.6.0)
 Copyright-File: LICENSE.txt
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic cosmic disco eoan buster
+Suite3: bionic cosmic disco eoan focal jammy buster bullseye
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
* Drop Ubuntu Xenial and surrounding non-LTS distributions
* Drop Debian Jessie and Debian Stretch which are no longer supported
  upstream
* Add Debian Bullseye
* Add Ubuntu Jammy