### PR TITLE
Drop support for python <= 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import sys
 
 from setuptools import find_packages, setup
 
@@ -38,9 +37,6 @@ kwargs = {
     'long_description': 'A tool to work with rosdistro files',
     'license': 'BSD, MIT'
 }
-
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-    kwargs['install_requires'].append('argparse')
 
 if 'SKIP_PYTHON_MODULES' in os.environ:
     kwargs['packages'] = []

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,7 +3,7 @@ Debian-Version: 100
 ; rosdistro-modules same version as in:
 ; - setup.py
 ; - src/rosdistro/__init__.py
-Depends: ca-certificates, python-argparse, python-rosdistro-modules (>= 0.8.3), python-setuptools, python-yaml
+Depends: ca-certificates, python-rosdistro-modules (>= 0.8.3), python-setuptools, python-yaml
 ; rosdistro-modules same version as in:
 ; - setup.py
 ; - src/rosdistro/__init__.py


### PR DESCRIPTION
Python 2.6 stopped shipping security fixes in 2013.