### PR TITLE
Run tests with pytest instead of nose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ deb_dist
 dist
 *.pyc
 rosdistro.egg-info
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ testsetup:
 	echo "running rosdistro! tests"
 
 test: testsetup
-	python setup.py nosetests
+	cd test && pytest
 
 test--pdb-failures: testsetup
-	python setup.py nosetests --pdb-failures
+	cd test && pytest --pdb

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ all_files  = 1
 [upload_sphinx]
 upload-dir = doc/build/html
 
-[nosetests]
-with-coverage=true
-cover-package=rosdistro
+[tool:pytest]
+junit_suite_name = rosdistro
+
+[coverage:run]
+source = rosdistro

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'src'))


### PR DESCRIPTION
Official nose documentation recommends users migrate to a more supported platform.