### PR TITLE
fix(dependency_walker): don't get dependencies of non ROS packages

### DIFF
--- a/src/rosdistro/dependency_walker.py
+++ b/src/rosdistro/dependency_walker.py
@@ -62,6 +62,9 @@ class DependencyWalker(object):
 
     def get_depends(self, pkg_name, depend_type, ros_packages_only=False):
         '''Return a set of package names which the package depends on.'''
+        # We can only get the dependencies of ROS packages
+        if pkg_name not in self._get_package_names():
+          return set()
         deps = self._get_dependencies(pkg_name, depend_type)
         if ros_packages_only:
             deps &= set(self._get_package_names())

--- a/src/rosdistro/dependency_walker.py
+++ b/src/rosdistro/dependency_walker.py
@@ -64,7 +64,7 @@ class DependencyWalker(object):
         '''Return a set of package names which the package depends on.'''
         # We can only get the dependencies of ROS packages
         if pkg_name not in self._get_package_names():
-          return set()
+          raise KeyError("Package '%s' not found" % pkg_name)
         deps = self._get_dependencies(pkg_name, depend_type)
         if ros_packages_only:
             deps &= set(self._get_package_names())


### PR DESCRIPTION
When using the `DependencyWalker` and calling `get_recursive_depends` with the `ros_packages_only` to `False`, the `DependencyWalker` tries to [get the dependencies of every dependency](https://github.com/ros-infrastructure/rosdistro/blob/master/src/rosdistro/dependency_walker.py#L82) (even the non-ROS ones).
In order to get the dependencies of a package we must get [the corresponding ROS package](https://github.com/ros-infrastructure/rosdistro/blob/master/src/rosdistro/dependency_walker.py#L44) (for the XML etc). This is not possible for non ROS packages (like `CMake`, `boost` etc). Hence this causes a [`KeyError`](https://github.com/ros-infrastructure/rosdistro/blob/master/src/rosdistro/dependency_walker.py#L46).

I simply added a check to verify if the package is a ROS package or not before trying to get its dependencies.