### PR TITLE
Switch to a raw string for various regexes.

### DIFF
--- a/src/rosdistro/distribution_cache_generator.py
+++ b/src/rosdistro/distribution_cache_generator.py
@@ -107,7 +107,7 @@ def generate_distribution_cache(index, dist_name, preclean=False, ignore_local=F
             errors.append('%s: invalid package.xml file for package "%s": %s' % (dist_name, pkg_name, e))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s(-[\dA-z~\+\.]+)?$' % re.escape(pkg.version), repo.version):
+        if not re.match(r'^%s(-[\dA-z~\+\.]+)?$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
         if package_xml != old_package_xml:

--- a/src/rosdistro/external/appdirs.py
+++ b/src/rosdistro/external/appdirs.py
@@ -99,7 +99,7 @@ def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
 
 
 def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
-    """Return full path to the user-shared data dir for this application.
+    r"""Return full path to the user-shared data dir for this application.
 
         "appname" is the name of application.
             If None, just the system directory is returned.
@@ -200,7 +200,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
 
 
 def site_config_dir(appname=None, appauthor=None, version=None, multipath=False):
-    """Return full path to the user-shared data dir for this application.
+    r"""Return full path to the user-shared data dir for this application.
 
         "appname" is the name of application.
             If None, just the system directory is returned.

--- a/src/rosdistro/release_cache_generator.py
+++ b/src/rosdistro/release_cache_generator.py
@@ -96,7 +96,7 @@ def generate_release_cache(index, dist_name, preclean=False, debug=False):
             errors.append('%s: invalid package.xml file for package "%s"' % (dist_name, pkg_name))
             continue
         # check that version numbers match (at least without deb inc)
-        if not re.match('^%s(-[\dA-z~\+\.]+)?$' % re.escape(pkg.version), repo.version):
+        if not re.match(r'^%s(-[\dA-z~\+\.]+)?$' % re.escape(pkg.version), repo.version):
             errors.append('%s: different version in package.xml (%s) for package "%s" than for the repository (%s) (after removing the debian increment)' % (dist_name, pkg.version, pkg_name, repo.version))
 
     if not debug:

--- a/src/rosdistro/repository_specification.py
+++ b/src/rosdistro/repository_specification.py
@@ -38,7 +38,7 @@ from .vcs import Git
 
 class RepositorySpecification(object):
     # Match groups are server and path on server.
-    VCS_REGEX = re.compile('(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)((?:[a-fA-F0-9]{40}@)?[\w.-]+)[:/]([\w/-]*)(?:\.git)?$')
+    VCS_REGEX = re.compile(r'(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)((?:[a-fA-F0-9]{40}@)?[\w.-]+)[:/]([\w/-]*)(?:\.git)?$')
 
     def __init__(self, name, data):
         self.name = name


### PR DESCRIPTION
Otherwise, when running against Python 3.12, we see warnings like SyntaxWarning: invalid escape sequence '\d'

This should fix warnings that we see in jobs like https://build.ros2.org/view/Queue/job/Rsrc_uN__ackermann_msgs__ubuntu_noble__source/1/consoleFull