### PR TITLE
Cleanup CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,22 +12,20 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python: ['3.7', '3.8', '3.9', '3.10']
         include:
-        - os: ubuntu-18.04
-          python: '2.7'
-        - os: ubuntu-18.04
+        - os: ubuntu-20.04
           python: '3.6'
     name: rosdistro tests
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{matrix.python}}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{matrix.python}}
     - name: Install dependencies
       run: |
-        python -m pip install -U -e .[test] pytest-cov -c constraints.txt
+        python -m pip install -U -e .[test] pytest-cov
     - name: Run tests
       run: |
         python -m pytest test --cov

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,0 @@
-pyparsing==2.4.7; python_version < '3'
-PyYAML<6.0; python_version < '3'


### PR DESCRIPTION
This makes it match CI in https://github.com/ros-infrastructure/catkin-pkg.

Essentially removes Python 2.7 testing, removes Ubuntu 18.04, removes the now-unnecessary constraints.txt, and updates the versions of the actions we depend on.