### PR TITLE
Make path operations and conversions portable in tests

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,15 @@
 import os
 import sys
+try:
+    from urllib.parse import urljoin
+    from urllib.request import pathname2url
+except ImportError:
+    from urlparse import urljoin
+    from urllib import pathname2url
 
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
     'src'))
+
+def path_to_url(path):
+    return urljoin('file:', pathname2url(path))

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -2,10 +2,12 @@ import os
 
 from rosdistro import get_distribution_cache, get_index
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_get_release_cache():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     get_distribution_cache(i, 'foo')

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -6,11 +6,13 @@ from rosdistro.loader import load_url
 
 import yaml
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_distribution_file():
-    url = 'file://' + FILES_DIR + '/foo/distribution.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'foo', 'distribution.yaml'))
     yaml_str = load_url(url)
     data = yaml.safe_load(yaml_str)
     dist_file = DistributionFile('foo', data)
@@ -18,7 +20,7 @@ def test_distribution_file():
 
 
 def test_get_distribution_file():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     dist_file = get_distribution_file(i, 'foo')
     _validate_dist_file(dist_file)

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -6,11 +6,13 @@ from rosdistro.loader import load_url
 
 import yaml
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_doc_file():
-    url = 'file://' + FILES_DIR + '/foo/distribution.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'foo', 'distribution.yaml'))
     yaml_str = load_url(url)
     data = yaml.safe_load(yaml_str)
     doc_file = DocFile('foo', data)
@@ -18,7 +20,7 @@ def test_doc_file():
 
 
 def test_get_doc_file():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     doc_file = get_doc_file(i, 'foo')
     _validate_doc_file(doc_file)

--- a/test/test_doc_build.py
+++ b/test/test_doc_build.py
@@ -6,18 +6,20 @@ from rosdistro.loader import load_url
 
 import yaml
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_doc_build_file():
-    url = 'file://' + FILES_DIR + '/foo/doc-build.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'foo', 'doc-build.yaml'))
     yaml_str = load_url(url)
     data = yaml.safe_load(yaml_str)
     DocBuildFile('foo', data)
 
 
 def test_get_doc_build_files():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     files = get_doc_build_files(i, 'foo')
     assert len(files) == 1

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -5,6 +5,8 @@ from rosdistro import get_distribution_files
 from rosdistro import get_index
 from rosdistro import get_index_url
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
@@ -13,7 +15,7 @@ def test_get_index_url():
 
 
 def test_get_index_v2():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     assert len(i.distributions.keys()) == 1
     assert 'foo' in i.distributions.keys()
@@ -23,7 +25,7 @@ def test_get_index_v2():
 
 
 def test_get_index_v3():
-    url = 'file://' + FILES_DIR + '/index_v3.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v3.yaml'))
     i = get_index(url)
     assert len(i.distributions.keys()) == 1
     assert 'foo' in i.distributions.keys()
@@ -37,7 +39,7 @@ def test_get_index_v3():
 
 
 def test_get_index_v3_invalid():
-    url = 'file://' + FILES_DIR + '/index_v3_invalid.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v3_invalid.yaml'))
     i = get_index(url)
 
     dist_files = get_distribution_files(i, 'foo')
@@ -50,7 +52,7 @@ def test_get_index_v3_invalid():
 
 
 def test_get_index_v4():
-    url = 'file://' + FILES_DIR + '/index_v4.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v4.yaml'))
     i = get_index(url)
     assert len(i.distributions.keys()) == 1
     assert 'foo' in i.distributions.keys()

--- a/test/test_manifest_providers.py
+++ b/test/test_manifest_providers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 try:
     from unittest.mock import patch
 except ImportError:
@@ -109,7 +111,7 @@ def test_git_source_multi():
     repo_cache = git_source_manifest_provider(_ros_source_repo())
     assert repo_cache.ref()
     package_path, package_xml = repo_cache['roslib']
-    assert package_path == 'core/roslib'
+    assert package_path == os.path.join('core', 'roslib')
 
 
 def test_tar_source():

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -6,11 +6,13 @@ from rosdistro.release_file import ReleaseFile
 
 import yaml
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_release_file():
-    url = 'file://' + FILES_DIR + '/foo/distribution.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'foo', 'distribution.yaml'))
     yaml_str = load_url(url)
     data = yaml.safe_load(yaml_str)
     rel_file = ReleaseFile('foo', data)
@@ -18,7 +20,7 @@ def test_release_file():
 
 
 def test_get_release_file():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     rel_file = get_release_file(i, 'foo')
     _validate_rel_file(rel_file)

--- a/test/test_release_build.py
+++ b/test/test_release_build.py
@@ -6,24 +6,26 @@ from rosdistro.release_build_file import ReleaseBuildFile
 
 import yaml
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_release_build_file():
-    url = 'file://' + FILES_DIR + '/foo/release-build.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'foo', 'release-build.yaml'))
     yaml_str = load_url(url)
     data = yaml.safe_load(yaml_str)
     ReleaseBuildFile('foo', data)
 
 
 def test_get_release_build_files():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     get_release_build_files(i, 'foo')
 
 
 def test_get_release_builds():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     d = get_release(i, 'foo')
     builds = get_release_builds(i, d)

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -6,11 +6,13 @@ from rosdistro.source_file import SourceFile
 
 import yaml
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_source_file():
-    url = 'file://' + FILES_DIR + '/foo/distribution.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'foo', 'distribution.yaml'))
     yaml_str = load_url(url)
     data = yaml.safe_load(yaml_str)
     src_file = SourceFile('foo', data)
@@ -18,7 +20,7 @@ def test_source_file():
 
 
 def test_get_source_file():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     src_file = get_source_file(i, 'foo')
     _validate_src_file(src_file)

--- a/test/test_source_build.py
+++ b/test/test_source_build.py
@@ -6,18 +6,20 @@ from rosdistro.source_build_file import SourceBuildFile
 
 import yaml
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_source_build_file():
-    url = 'file://' + FILES_DIR + '/foo/source-build.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'foo', 'source-build.yaml'))
     yaml_str = load_url(url)
     data = yaml.safe_load(yaml_str)
     SourceBuildFile('foo', data)
 
 
 def test_get_source_build_files():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     i = get_index(url)
     files = get_source_build_files(i, 'foo')
     assert len(files) == 1

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -2,14 +2,16 @@ import os
 
 from rosdistro.verify import verify_files_identical, verify_files_parsable
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
 def test_verify_files_parsable():
-    index_url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    index_url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     assert verify_files_parsable(index_url)
 
 
 def test_verify_files_identical():
-    index_url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    index_url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     assert verify_files_identical(index_url)

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -5,6 +5,8 @@ from rosdistro import get_distribution_file, get_index
 
 from rosdistro.writer import yaml_from_distribution_file
 
+from . import path_to_url
+
 FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files'))
 
 
@@ -30,7 +32,7 @@ def get_diff(expected, actual):
 
 
 def test_verify_files_parsable():
-    url = 'file://' + FILES_DIR + '/index_v2.yaml'
+    url = path_to_url(os.path.join(FILES_DIR, 'index_v2.yaml'))
     index = get_index(url)
     distribution_file = get_distribution_file(index, 'foo')
     data = yaml_from_distribution_file(distribution_file)


### PR DESCRIPTION
Two classes of issues:
1. Use `os.path.join` instead of string concatenation
2. Use `urljoin`/`pathname2url` to create `file://` URLs