### PR TITLE
Don't use os.path.sep for creating tar paths

### DIFF
--- a/src/rosdistro/manifest_provider/tar.py
+++ b/src/rosdistro/manifest_provider/tar.py
@@ -69,7 +69,7 @@ def tar_manifest_provider(_dist_name, repo, pkg_name):
 
     response = urlopen(request)
     with tarfile.open(fileobj=io.BytesIO(response.read())) as tar:
-        package_xml = tar.extractfile(os.path.join(subdir, 'package.xml')).read()
+        package_xml = tar.extractfile(subdir + '/package.xml').read()
 
         # Python2 returns strings, Python3 returns bytes-- support both
         try:


### PR DESCRIPTION
The paths to files within a tarball should always use '/' as a separator. This is particularly important on Windows, where os.path.sep is '\'.