### PR TITLE
Don't capture stderr when running git commands

### DIFF
--- a/src/rosdistro/vcs.py
+++ b/src/rosdistro/vcs.py
@@ -67,7 +67,7 @@ def ref_is_hash(ref):
 def _run_command(cmd, cwd=None, env=None):
     result = {'cmd': ' '.join(cmd), 'cwd': cwd}
     try:
-        proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+        proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, env=env)
         output, _ = proc.communicate()
         result['output'] = output.rstrip()
         result['returncode'] = proc.returncode


### PR DESCRIPTION
The output of these commands is sometimes parsed, and output from stderr can interfere with that parsing.