### PR TITLE
Drop support for Python 2

### DIFF
--- a/scripts/rosdistro
+++ b/scripts/rosdistro
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import optparse
 import sys

--- a/scripts/rosdistro_build_cache
+++ b/scripts/rosdistro_build_cache
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/rosdistro_convert
+++ b/scripts/rosdistro_convert
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/rosdistro_freeze_source
+++ b/scripts/rosdistro_freeze_source
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/rosdistro_generate_cache
+++ b/scripts/rosdistro_generate_cache
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import optparse
 import sys

--- a/scripts/rosdistro_migrate_to_rep_141
+++ b/scripts/rosdistro_migrate_to_rep_141
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/rosdistro_migrate_to_rep_143
+++ b/scripts/rosdistro_migrate_to_rep_143
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/rosdistro_reformat
+++ b/scripts/rosdistro_reformat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 
@@ -11,6 +11,7 @@ kwargs = {
     # - stdeb.cfg
     'version': '0.9.1',
     'install_requires': ['PyYAML', 'setuptools'],
+    'python_requires': '>=3.6',
     'packages': find_packages('src'),
     'package_dir': {'': 'src'},
     'scripts': [
@@ -25,7 +26,6 @@ kwargs = {
     ],
     'extras_require': {
         'test': [
-            "mock; python_version < '3.3'",
             'pytest',
         ]},
     'author': 'Wim Meeussen, Dirk Thomas',

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,30 +3,20 @@ Debian-Version: 100
 ; rosdistro-modules same version as in:
 ; - setup.py
 ; - src/rosdistro/__init__.py
-Depends: ca-certificates, python-rosdistro-modules (>= 0.9.1), python-setuptools, python-yaml
-; rosdistro-modules same version as in:
-; - setup.py
-; - src/rosdistro/__init__.py
 Depends3: ca-certificates, python3-rosdistro-modules (>= 0.9.1), python3-setuptools, python3-yaml
-Conflicts: python3-rosdistro
 Conflicts3: python-rosdistro
 Copyright-File: LICENSE.txt
-Suite: bionic cosmic disco eoan buster
 Suite3: focal jammy noble bookworm trixie
-Python2-Depends-Name: python
-X-Python3-Version: >= 3.4
+No-Python2:
+X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [rosdistro_modules]
-Depends: ca-certificates, python-catkin-pkg-modules, python-rospkg-modules, python-setuptools, python-yaml
 Depends3: ca-certificates, python3-catkin-pkg-modules, python3-rospkg-modules, python3-setuptools, python3-yaml
-Conflicts: python-rosdistro (<< 0.6.0)
 Conflicts3: python3-rosdistro (<< 0.6.0)
-Replaces: python-rosdistro (<< 0.6.0)
 Replaces3: python3-rosdistro (<< 0.6.0)
 Copyright-File: LICENSE.txt
-Suite: bionic cosmic disco eoan buster
 Suite3: focal jammy noble bookworm trixie
-Python2-Depends-Name: python
-X-Python3-Version: >= 3.4
+No-Python2:
+X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1

--- a/test/test_manifest_providers.py
+++ b/test/test_manifest_providers.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 import rosdistro.manifest_provider.github
 import rosdistro.vcs


### PR DESCRIPTION
* The minimum Python version is now 3.6
* Shebangs now use python3 specifically
* Use of the 'mock' backport package has been removed