### PR TITLE
Remove more Python 2 artifacts

### DIFF
--- a/scripts/rosdistro_build_cache
+++ b/scripts/rosdistro_build_cache
@@ -90,9 +90,7 @@ def main():
         if args.dist_names and dist_name not in args.dist_names:
             continue
         # write the cache
-        data = yaml.dump(cache.get_data(), Dumper=CacheYamlDumper)
-
-        data = data.encode('utf-8')
+        data = yaml.dump(cache.get_data(), Dumper=CacheYamlDumper).encode()
 
         with open('%s-cache.yaml' % dist_name, 'wb') as f:
             print('- write cache file "%s-cache.yaml"' % dist_name)

--- a/scripts/rosdistro_build_cache
+++ b/scripts/rosdistro_build_cache
@@ -33,8 +33,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import argparse
 import gzip
 import logging
@@ -94,11 +92,7 @@ def main():
         # write the cache
         data = yaml.dump(cache.get_data(), Dumper=CacheYamlDumper)
 
-        # On Python 3, we must encode the unicode yaml str prior to writing it,
-        # whereas for Python 2, the yaml output is a str which cannot be further
-        # encoded (compared with a unicode object).
-        if sys.version_info[0] >= 3:
-            data = data.encode('utf-8')
+        data = data.encode('utf-8')
 
         with open('%s-cache.yaml' % dist_name, 'wb') as f:
             print('- write cache file "%s-cache.yaml"' % dist_name)

--- a/scripts/rosdistro_convert
+++ b/scripts/rosdistro_convert
@@ -33,16 +33,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import os
 import subprocess
 import sys
 import tempfile
-try:
-    from urllib.error import HTTPError
-except ImportError:
-    from urllib2 import HTTPError
+from urllib.error import HTTPError
 
 from rosdistro.common import rmtree
 from rosdistro.loader import load_url

--- a/scripts/rosdistro_freeze_source
+++ b/scripts/rosdistro_freeze_source
@@ -33,8 +33,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import argparse
 import os.path
 import sys

--- a/scripts/rosdistro_migrate_to_rep_141
+++ b/scripts/rosdistro_migrate_to_rep_141
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 import gzip
 import os

--- a/scripts/rosdistro_migrate_to_rep_143
+++ b/scripts/rosdistro_migrate_to_rep_143
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 
 from rosdistro.verify import _yaml_header_lines

--- a/src/rosdistro/__init__.py
+++ b/src/rosdistro/__init__.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import gzip
 import logging
 import os

--- a/src/rosdistro/aptdistro.py
+++ b/src/rosdistro/aptdistro.py
@@ -1,7 +1,4 @@
-try:
-    from urllib2 import urlopen
-except ImportError:
-    from urllib.request import urlopen
+from urllib.request import urlopen
 
 
 class AptDistro:

--- a/src/rosdistro/common.py
+++ b/src/rosdistro/common.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from errno import EACCES, EPERM
 import os
 import shutil

--- a/src/rosdistro/develdistro.py
+++ b/src/rosdistro/develdistro.py
@@ -1,7 +1,5 @@
-try:
-    from urllib.request import urlopen
-except ImportError:
-    from urllib2 import urlopen
+from urllib.request import urlopen
+
 import yaml
 
 

--- a/src/rosdistro/distribution_cache.py
+++ b/src/rosdistro/distribution_cache.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import sys
 
 from . import logger
@@ -70,11 +68,6 @@ class DistributionCache(object):
             for repo_name, repo_data in data['source_repo_package_xmls'].items():
                 self.source_repo_package_xmls[repo_name] = SourceRepositoryCache(repo_data)
         self.distribution_file.source_packages = self.get_source_packages()
-
-        # if Python 2 has converted the xml to unicode, convert it back
-        for k, v in self.release_package_xmls.items():
-            if not isinstance(v, str) and not isinstance(v, bytes):
-                self.release_package_xmls[k] = v.encode('utf-8')
 
     def get_data(self):
         data = {}

--- a/src/rosdistro/distribution_cache_generator.py
+++ b/src/rosdistro/distribution_cache_generator.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import gzip
 import os
 import re
@@ -155,12 +153,7 @@ class CacheYamlDumper(yaml.SafeDumper):
 
     def ignore_aliases(self, content):
         """ Allow strings that look like package XML to alias to each other in the YAML output. """
-        try:
-            basestring
-        except NameError:
-            # Python 3
-            basestring = str
-        return not (isinstance(content, basestring) and '<package' in content)
+        return not (isinstance(content, str) and '<package' in content)
 
     def represent_mapping(self, tag, mapping, flow_style=False):
         """ Gives compact representation for the distribution_file section, while allowing the package

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import subprocess
 import sys
 import threading
@@ -108,11 +106,6 @@ def _worker(work_queue):
                 elif ref in ('refs/heads/%s' % freeze_version, 'refs/tags/%s' % freeze_version):
                     source_repo.version = hash
                     break
-
-            if not isinstance(source_repo.version, str):
-                # On Python 2, explicitly encode back to string. Unnecessary on Python 3, because
-                # we're already a unicode string since subprocess.check_output returned a bytes.
-                source_repo.version = source_repo.version.encode()
 
             work_queue.task_done()
 

--- a/src/rosdistro/legacy.py
+++ b/src/rosdistro/legacy.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import gzip
 try:
     from cStringIO import StringIO

--- a/src/rosdistro/loader.py
+++ b/src/rosdistro/loader.py
@@ -33,14 +33,9 @@
 
 import socket
 import time
-try:
-    from urllib.request import urlopen
-    from urllib.error import HTTPError
-    from urllib.error import URLError
-except ImportError:
-    from urllib2 import urlopen
-    from urllib2 import HTTPError
-    from urllib2 import URLError
+from urllib.request import urlopen
+from urllib.error import HTTPError
+from urllib.error import URLError
 
 
 def load_url(url, retry=2, retry_period=1, timeout=10, skip_decode=False):
@@ -59,9 +54,8 @@ def load_url(url, retry=2, retry_period=1, timeout=10, skip_decode=False):
         raise URLError(str(e) + ' (%s)' % url)
     except socket.timeout as e:
         raise socket.timeout(str(e) + ' (%s)' % url)
-    # Python 2/3 Compatibility
     contents = fh.read()
-    if isinstance(contents, str) or skip_decode:
+    if skip_decode:
         return contents
     else:
         return contents.decode('utf-8')

--- a/src/rosdistro/manifest_provider/bitbucket.py
+++ b/src/rosdistro/manifest_provider/bitbucket.py
@@ -31,15 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-try:
-    from urllib.request import urlopen, Request
-    from urllib.error import URLError
-except ImportError:
-    from urllib2 import urlopen, Request
-    from urllib2 import URLError
-
 import base64
 import os
+from urllib.request import urlopen, Request
+from urllib.error import URLError
 
 from rosdistro import logger
 

--- a/src/rosdistro/manifest_provider/cache.py
+++ b/src/rosdistro/manifest_provider/cache.py
@@ -38,8 +38,7 @@ from rosdistro import logger
 
 def sanitize_xml(xml_string):
     """ Returns a version of the supplied XML string with comments and all whitespace stripped,
-    including runs of spaces internal to text nodes. The returned string will be encoded,
-    so str (Python 2) or bytes (Python 3).
+    including runs of spaces internal to text nodes. The returned value will be bytes.
     """
     def _squash(node):
         # remove comment nodes
@@ -58,22 +57,9 @@ def sanitize_xml(xml_string):
             if x.nodeType == minidom.Node.ELEMENT_NODE:
                 _squash(x)
         return node
-    try:
-        # Python 2. The minidom module parses as ascii, so we have to pre-encode.
-        if isinstance(xml_string, unicode):
-            xml_string = xml_string.encode('utf-8')
-    except NameError:
-        # Python 3. Strings are native unicode.
-        pass
 
     xml_node = _squash(minidom.parseString(xml_string))
-    try:
-        # Python 2. Encode the resultant XML as a str.
-        unicode
-        return xml_node.toxml('utf-8')
-    except NameError:
-        # Python 3. Return native bytes.
-        return xml_node.toxml()
+    return xml_node.toxml()
 
 
 class CachedManifestProvider(object):

--- a/src/rosdistro/manifest_provider/github.py
+++ b/src/rosdistro/manifest_provider/github.py
@@ -31,16 +31,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-try:
-    from urllib.request import urlopen, Request
-    from urllib.error import URLError
-except ImportError:
-    from urllib2 import urlopen, Request
-    from urllib2 import URLError
-
 import base64
 import json
 import os
+from urllib.request import urlopen, Request
+from urllib.error import URLError
 
 from catkin_pkg.package import parse_package_string
 

--- a/src/rosdistro/manifest_provider/tar.py
+++ b/src/rosdistro/manifest_provider/tar.py
@@ -36,11 +36,7 @@ import os
 import tarfile
 import tempfile
 import urllib
-
-try:
-    from urllib.request import urlopen, Request
-except ImportError:
-    from urllib2 import urlopen, Request
+from urllib.request import urlopen, Request
 
 from catkin_pkg.package import InvalidPackage, parse_package_string
 from catkin_pkg.packages import find_package_paths
@@ -70,12 +66,7 @@ def tar_manifest_provider(_dist_name, repo, pkg_name):
     response = urlopen(request)
     with tarfile.open(fileobj=io.BytesIO(response.read())) as tar:
         package_xml = tar.extractfile(subdir + '/package.xml').read()
-
-        # Python2 returns strings, Python3 returns bytes-- support both
-        try:
-            return package_xml.decode('utf-8')
-        except AttributeError:
-            return package_xml
+        return package_xml.decode('utf-8')
 
 
 def tar_source_manifest_provider(repo):

--- a/src/rosdistro/release_cache.py
+++ b/src/rosdistro/release_cache.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 from .release_file import ReleaseFile
 
 

--- a/src/rosdistro/release_cache_generator.py
+++ b/src/rosdistro/release_cache_generator.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import gzip
 import os
 import re

--- a/src/rosdistro/rosdistro.py
+++ b/src/rosdistro/rosdistro.py
@@ -4,12 +4,8 @@ import sys
 import tarfile
 import tempfile
 import threading
-try:
-    from urllib.request import urlopen
-    from urllib.error import HTTPError
-except ImportError:
-    from urllib2 import urlopen
-    from urllib2 import HTTPError
+from urllib.request import urlopen
+from urllib.error import HTTPError
 
 import yaml
 
@@ -382,8 +378,6 @@ def retrieve_dependencies(package_xml):
 
 
 def get_package_dependencies(package_xml):
-    if not os.path.abspath("/usr/lib/pymodules/python2.7") in sys.path:
-        sys.path.append("/usr/lib/pymodules/python2.7")
     from catkin_pkg import package as catkin_pkg
 
     pkg = catkin_pkg.parse_package_string(package_xml)

--- a/src/rosdistro/verify.py
+++ b/src/rosdistro/verify.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import difflib
 import sys
 

--- a/src/rosdistro/writer.py
+++ b/src/rosdistro/writer.py
@@ -31,8 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 from .verify import _to_yaml, _yaml_header_lines
 
 

--- a/test/test_manifest_providers.py
+++ b/test/test_manifest_providers.py
@@ -62,15 +62,9 @@ def test_git_source():
 def mock_get_url_contents(req):
     import re
 
-    # For python3, look for the 'str' type; for Python 2, the 'unicode' type
-    try:
-        text_type = unicode
-    except NameError:
-        text_type = str
-
-    # The urlopen() function from urllib or urllib2 takes either a string or a
-    # urllib.Request object in; determine the URL in either case.
-    if isinstance(req, text_type):
+    # The urlopen() function from urllib takes either a string or a
+    # urllib.request.Request object in; determine the URL in either case.
+    if isinstance(req, str):
         haystack = req
     else:
         haystack = req.get_full_url()
@@ -124,7 +118,7 @@ def test_sanitize():
     assert '<a>abc</a>' in sanitize_xml('<a>ab<!-- comment -->c</a>')
     assert '<a><b/><c>ab c</c></a>' in sanitize_xml('<a><b> </b>  <c>  ab  c  </c></a>')
 
-    # This unicode check should be valid on both Python 2 and 3.
+    # This unicode check should be valid.
     assert '<a>français</a>' in sanitize_xml('<a> français  </a>')
 
     # subsequent parse calls will collapse empty tags, therefore sanitize should do the same


### PR DESCRIPTION
We no longer support Python 2 in rosdistro so there's no reason to carry these snippets anymore.