### PR TITLE
Clean up script entry points

### DIFF
--- a/scripts/rosdistro
+++ b/scripts/rosdistro
@@ -83,4 +83,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/rosdistro_build_cache
+++ b/scripts/rosdistro_build_cache
@@ -84,7 +84,7 @@ def main():
             ignore_local=args.ignore_local, include_source=args.include_source, debug=args.debug)
     except RuntimeError as e:
         print(str(e), file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     for dist_name, cache in caches.items():
         if args.dist_names and dist_name not in args.dist_names:
@@ -101,4 +101,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/scripts/rosdistro_convert
+++ b/scripts/rosdistro_convert
@@ -257,10 +257,14 @@ def convert_doc(dist_name):
         f.write(yaml_str)
 
 
-if __name__ == '__main__':
+def main():
     targets = get_targets()
     for distro in ['groovy', 'hydro']:
         print('\nConverting "%s"\n' % distro)
         convert_release(distro, targets)
         convert_source(distro)
         convert_doc(distro)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/rosdistro_freeze_source
+++ b/scripts/rosdistro_freeze_source
@@ -95,4 +95,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/scripts/rosdistro_generate_cache
+++ b/scripts/rosdistro_generate_cache
@@ -34,4 +34,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/rosdistro_migrate_to_rep_141
+++ b/scripts/rosdistro_migrate_to_rep_141
@@ -3,6 +3,7 @@
 import argparse
 import gzip
 import os
+import sys
 
 try:
     from cStringIO import StringIO
@@ -163,9 +164,13 @@ def get_dict_parts(d, keys):
     return data
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description='Migrate the distros from REP 137 to REP 141.')
     parser.add_argument('index', help='The index.yaml file to migrate')
     args = parser.parse_args()
 
     migrate(args.index)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rosdistro_migrate_to_rep_143
+++ b/scripts/rosdistro_migrate_to_rep_143
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
 
 from rosdistro.verify import _yaml_header_lines
 
@@ -32,9 +33,13 @@ def index_to_yaml(data):
     return yaml_str
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description='Migrate the distros from REP 141 to REP 143.')
     parser.add_argument('index', help='The index.yaml file to migrate')
     args = parser.parse_args()
 
     migrate(args.index)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rosdistro_reformat
+++ b/scripts/rosdistro_reformat
@@ -55,7 +55,7 @@ def parse_args(args=sys.argv[1:]):
     return parser.parse_args(args)
 
 
-if __name__ == '__main__':
+def main():
     args = parse_args()
     index = args.index
     if os.path.isfile(index):
@@ -64,4 +64,8 @@ if __name__ == '__main__':
         success = verify_files_identical(index)
     else:
         success = reformat_files(index)
-    sys.exit(0 if success else 1)
+    return 0 if success else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Two factors here:
1. Ensure that each script has an explicit main() function
2. Ensure that the return value of main() is the return value of the program when the script is invoked directly.