### PR TITLE
Re-add deprecated scripts, drop shebang from cli modules

### DIFF
--- a/scripts/rosdistro
+++ b/scripts/rosdistro
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rosdistro.cli.rosdistro import main
+
+if __name__ == '__main__':
+    print('The rosdistro script is deprecated. Use python3 '
+          "-m 'rosdistro.cli.rosdistro' instead.\n",
+          file=sys.stderr)
+    sys.exit(main())

--- a/scripts/rosdistro_build_cache
+++ b/scripts/rosdistro_build_cache
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rosdistro.cli.rosdistro_build_cache import main
+
+if __name__ == '__main__':
+    print('The rosdistro_build_cache script is deprecated. Use python3 '
+          "-m 'rosdistro.cli.rosdistro_build_cache' instead.\n",
+          file=sys.stderr)
+    sys.exit(main())

--- a/scripts/rosdistro_convert
+++ b/scripts/rosdistro_convert
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rosdistro.cli.rosdistro_convert import main
+
+if __name__ == '__main__':
+    print('The rosdistro_convert is deprecated. Use python3 '
+          "-m 'rosdistro.cli.rosdistro_convert' instead.\n",
+          file=sys.stderr)
+    sys.exit(main())

--- a/scripts/rosdistro_freeze_source
+++ b/scripts/rosdistro_freeze_source
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rosdistro.cli.rosdistro_freeze_source import main
+
+if __name__ == '__main__':
+    print('The rosdistro_freeze_source script is deprecated. Use python3 '
+          "-m 'rosdistro.cli.rosdistro_freeze_source' instead.\n",
+          file=sys.stderr)
+    sys.exit(main())

--- a/scripts/rosdistro_generate_cache
+++ b/scripts/rosdistro_generate_cache
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rosdistro.cli.rosdistro_generate_cache import main
+
+if __name__ == '__main__':
+    print('The rosdistro_generate_cache script is deprecated. Use python3 '
+          "-m 'rosdistro.cli.rosdistro_generate_cache' instead.\n",
+          file=sys.stderr)
+    sys.exit(main())

--- a/scripts/rosdistro_migrate_to_rep_141
+++ b/scripts/rosdistro_migrate_to_rep_141
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rosdistro.cli.rosdistro_migrate_to_rep_141 import main
+
+if __name__ == '__main__':
+    print('The rosdistro_migrate_to_rep_141 script is deprecated. Use python3 '
+          "-m 'rosdistro.cli.rosdistro_migrate_to_rep_141' instead.\n",
+          file=sys.stderr)
+    sys.exit(main())

--- a/scripts/rosdistro_migrate_to_rep_143
+++ b/scripts/rosdistro_migrate_to_rep_143
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rosdistro.cli.rosdistro_migrate_to_rep_143 import main
+
+if __name__ == '__main__':
+    print('The rosdistro_migrate_to_rep_143 script is deprecated. Use python3 '
+          "-m 'rosdistro.cli.rosdistro_migrate_to_rep_143' instead.\n",
+          file=sys.stderr)
+    sys.exit(main())

--- a/scripts/rosdistro_reformat
+++ b/scripts/rosdistro_reformat
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rosdistro.cli.rosdistro_reformat import main
+
+if __name__ == '__main__':
+    print('The rosdistro_reformat script is deprecated. Use python3 '
+          "-m 'rosdistro.cli.rosdistro_reformat' instead.\n",
+          file=sys.stderr)
+    sys.exit(main())

--- a/src/rosdistro/cli/rosdistro.py
+++ b/src/rosdistro/cli/rosdistro.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import optparse
 import sys
 

--- a/src/rosdistro/cli/rosdistro_build_cache.py
+++ b/src/rosdistro/cli/rosdistro_build_cache.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2013, Open Source Robotics Foundation, Inc.

--- a/src/rosdistro/cli/rosdistro_convert.py
+++ b/src/rosdistro/cli/rosdistro_convert.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2013, Open Source Robotics Foundation, Inc.

--- a/src/rosdistro/cli/rosdistro_freeze_source.py
+++ b/src/rosdistro/cli/rosdistro_freeze_source.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2016, Clearpath Robotics

--- a/src/rosdistro/cli/rosdistro_generate_cache.py
+++ b/src/rosdistro/cli/rosdistro_generate_cache.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import optparse
 import sys
 

--- a/src/rosdistro/cli/rosdistro_migrate_to_rep_141.py
+++ b/src/rosdistro/cli/rosdistro_migrate_to_rep_141.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 import gzip
 import os

--- a/src/rosdistro/cli/rosdistro_migrate_to_rep_143.py
+++ b/src/rosdistro/cli/rosdistro_migrate_to_rep_143.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 import sys
 

--- a/src/rosdistro/cli/rosdistro_reformat.py
+++ b/src/rosdistro/cli/rosdistro_reformat.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2013, Open Source Robotics Foundation, Inc.


### PR DESCRIPTION
This is a follow-up change to re-add deprecated scripts so we don't break any existing use of those scripts while folks migrate to better ways to invoke them.

Additionally, we can drop the shebangs and executable permissions from the CLI modules that were renamed in the previous commit.

This PR is in draft only until #186 has been merged, and can be reviewed as-is.