### PR TITLE
Fix entry_points removal for SKIP_PYTHON_SCRIPTS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if 'SKIP_PYTHON_MODULES' in os.environ:
     kwargs['package_dir'] = {}
 elif 'SKIP_PYTHON_SCRIPTS' in os.environ:
     kwargs['name'] += '_modules'
-    kwargs['entry_points'] = []
+    kwargs['entry_points'] = {}
 else:
     kwargs['install_requires'] += ['catkin_pkg', 'rospkg']
 


### PR DESCRIPTION
I needed this workaround to publish 1.0.0. Setuptools got mad about it.

Follow-up to 8de70e46840c65383d5a0791cade5b932ffe999c