### PR TITLE
Fix load_url retry for binary streams

### DIFF
--- a/src/rosdistro/loader.py
+++ b/src/rosdistro/loader.py
@@ -44,13 +44,13 @@ def load_url(url, retry=2, retry_period=1, timeout=10, skip_decode=False):
     except HTTPError as e:
         if e.code in [500, 502, 503] and retry:
             time.sleep(retry_period)
-            return load_url(url, retry=retry - 1, retry_period=retry_period, timeout=timeout)
+            return load_url(url, retry=retry - 1, retry_period=retry_period, timeout=timeout, skip_decode=skip_decode)
         e.msg += ' (%s)' % url
         raise
     except URLError as e:
         if isinstance(e.reason, socket.timeout) and retry:
             time.sleep(retry_period)
-            return load_url(url, retry=retry - 1, retry_period=retry_period, timeout=timeout)
+            return load_url(url, retry=retry - 1, retry_period=retry_period, timeout=timeout, skip_decode=skip_decode)
         raise URLError(str(e) + ' (%s)' % url)
     except socket.timeout as e:
         raise socket.timeout(str(e) + ' (%s)' % url)


### PR DESCRIPTION
This is a pretty old bug in the original binary stream implementation from #36.

Right now, it only triggers when we retry a binary stream download, as would be the case downloading the Gzip'd distribution cache.