### PR TITLE
Accept period in repo path regex

### DIFF
--- a/src/rosdistro/repository_specification.py
+++ b/src/rosdistro/repository_specification.py
@@ -38,7 +38,7 @@ from .vcs import Git
 
 class RepositorySpecification(object):
     # Match groups are server and path on server.
-    VCS_REGEX = re.compile(r'(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)((?:[a-fA-F0-9]{40}@)?[\w.-]+)[:/]([\w/-]*)(?:\.git)?$')
+    VCS_REGEX = re.compile(r'(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)((?:[a-fA-F0-9]{40}@)?[\w.-]+)[:/]([\w./-]*)(?:\.git)?$')
 
     def __init__(self, name, data):
         self.name = name

--- a/src/rosdistro/repository_specification.py
+++ b/src/rosdistro/repository_specification.py
@@ -38,7 +38,7 @@ from .vcs import Git
 
 class RepositorySpecification(object):
     # Match groups are server and path on server.
-    VCS_REGEX = re.compile(r'(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)((?:[a-fA-F0-9]{40}@)?[\w.-]+)[:/]([\w./-]*)(?:\.git)?$')
+    VCS_REGEX = re.compile(r'(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)((?:[a-fA-F0-9]{40}@)?[\w.-]+)[:/]([\w./-]*?)(?:\.git)?$')
 
     def __init__(self, name, data):
         self.name = name

--- a/test/test_repository_specification.py
+++ b/test/test_repository_specification.py
@@ -22,3 +22,6 @@ def test_repository_specification():
 
     r.url = 'https://1234567890abcdeABCDE1234567890abcdeABCDE@example.com:a/b/c/d/e.git'
     assert r.get_url_parts() == ('1234567890abcdeABCDE1234567890abcdeABCDE@example.com', 'a/b/c/d/e')
+
+    r.url = 'https://example.com/a.b/c.d/e.git'
+    assert r.get_url_parts() == ('example.com', 'a.b/c.d/e')


### PR DESCRIPTION
Example:

```
import rosdistro
import re

rosdistro.repository_specification.RepositorySpecification.VCS_REGEX = re.compile(
    r'(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)((?:[a-fA-F0-9]{40}@)?[\w.-]+)[:/]([\w./-]*)(?:\.git)?$')

index = rosdistro.get_index(rosdistro.get_index_url())
dist = rosdistro.get_distribution(index, "rolling")
for repo_name, repo_data in dist.repositories.items():
    if source := repo_data.source_repository:
        print(source.get_url_parts())
```

Without the monkey patch to the proposed regex, this fails on the current `rolling`:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/mikepurvis/rosdistro2nix/rosdistro2nix/cli.py", line 36, in main
    print(source.get_url_parts())
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mikepurvis/.cache/pypoetry/virtualenvs/rosdistro2nix-m92NI1Ci-py3.12/lib/python3.12/site-packages/rosdistro/repository_specification.py", line 62, in get_url_parts
    raise RuntimeError('VCS url "%s" does not match expected format.' % self.url)
RuntimeError: VCS url "https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git" does not match expected format.
```