### PR TITLE
Drop debugging output from gitlab manifest provider

### DIFF
--- a/src/rosdistro/manifest_provider/gitlab.py
+++ b/src/rosdistro/manifest_provider/gitlab.py
@@ -51,7 +51,7 @@ def _gitlab_urlopen(url):
     req = Request(url)
     if GITLAB_PRIVATE_TOKEN:
         req.add_header('Private-Token', GITLAB_PRIVATE_TOKEN)
-    logger.warn('Performing GitLab API query "%s"' % (url,))
+    logger.debug('Performing GitLab API query "%s"' % (url,))
     return urlopen(req)
 
 


### PR DESCRIPTION
This statement was clearly left over from debugging and can be demoted to 'debug' level.

Resolves:
```
src/rosdistro/manifest_provider/gitlab.py:54: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

Follow-up to #163.