### PR TITLE
Explicitly use 127.0.0.1 in http test

### DIFF
--- a/test/test_index.py
+++ b/test/test_index.py
@@ -75,7 +75,7 @@ def test_get_index_from_http_with_query_parameters():
     proc = subprocess.Popen(
         [sys.executable, '-m', 'http.server', '9876', '--bind', '127.0.0.1'],
         cwd=FILES_DIR)
-    time.sleep(1)
+    time.sleep(5)
     try:
         i = get_index(url)
         assert len(i.distributions.keys()) == 1

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -75,7 +75,7 @@ def test_get_index_from_http_with_query_parameters():
     proc = subprocess.Popen(
         [sys.executable, '-m', 'http.server', '9876', '--bind', '127.0.0.1'],
         cwd=FILES_DIR)
-    time.sleep(0.5)
+    time.sleep(1)
     try:
         i = get_index(url)
         assert len(i.distributions.keys()) == 1

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -70,14 +70,11 @@ def test_get_index_from_http_with_query_parameters():
     import subprocess
     import sys
     import time
-    url = 'http://localhost:9876/index_v3.yaml?raw&at=master'
+    url = 'http://127.0.0.1:9876/index_v3.yaml?raw&at=master'
     # start a http server and wait
-    if sys.version_info < (3, 0, 0):
-        proc = subprocess.Popen([sys.executable, '-m', 'SimpleHTTPServer', '9876'],
-                                cwd=FILES_DIR)
-    else:
-        proc = subprocess.Popen([sys.executable, '-m', 'http.server', '9876'],
-                                cwd=FILES_DIR)
+    proc = subprocess.Popen(
+        [sys.executable, '-m', 'http.server', '9876', '--bind', '127.0.0.1'],
+        cwd=FILES_DIR)
     time.sleep(0.5)
     try:
         i = get_index(url)

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -66,17 +66,32 @@ def test_get_index_v4():
     get_distribution_file(i, 'foo')
 
 
+def _wait_for_server():
+    import socket
+    import time
+    i = 0
+    while True:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.connect(('127.0.0.1', 9876))
+            except OSError:
+                if i >= 20:
+                    raise
+                time.sleep(0.1)
+            else:
+                return
+
+
 def test_get_index_from_http_with_query_parameters():
     import subprocess
     import sys
-    import time
     url = 'http://127.0.0.1:9876/index_v3.yaml?raw&at=master'
     # start a http server and wait
     proc = subprocess.Popen(
         [sys.executable, '-m', 'http.server', '9876', '--bind', '127.0.0.1'],
         cwd=FILES_DIR)
-    time.sleep(1)
     try:
+        _wait_for_server()
         i = get_index(url)
         assert len(i.distributions.keys()) == 1
         assert 'foo' in i.distributions.keys()

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -66,32 +66,17 @@ def test_get_index_v4():
     get_distribution_file(i, 'foo')
 
 
-def _wait_for_server():
-    import socket
-    import time
-    i = 0
-    while True:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            try:
-                s.connect(('127.0.0.1', 9876))
-            except OSError:
-                if i >= 20:
-                    raise
-                time.sleep(0.1)
-            else:
-                return
-
-
 def test_get_index_from_http_with_query_parameters():
     import subprocess
     import sys
+    import time
     url = 'http://127.0.0.1:9876/index_v3.yaml?raw&at=master'
     # start a http server and wait
     proc = subprocess.Popen(
         [sys.executable, '-m', 'http.server', '9876', '--bind', '127.0.0.1'],
         cwd=FILES_DIR)
+    time.sleep(1)
     try:
-        _wait_for_server()
         i = get_index(url)
         assert len(i.distributions.keys()) == 1
         assert 'foo' in i.distributions.keys()


### PR DESCRIPTION
We're experiencing some flaky behavior in this test on some platforms, and I suspect it's related to `localhost` resolving to an ipv6 address in some cases.